### PR TITLE
feat: 취약점 DB 상세 페이지 퍼블리싱

### DIFF
--- a/src/app/vulnerability-db/[id]/page.tsx
+++ b/src/app/vulnerability-db/[id]/page.tsx
@@ -1,0 +1,16 @@
+import DetailContent from "@/components/vulnerability-db/detail/DetailContent";
+import SimilarContent from "@/components/vulnerability-db/detail/SimilarContent";
+import Table from "@/components/vulnerability-db/detail/Table";
+
+function VulnerabilityDbDetailPage() {
+  return (
+    <>
+      <div className="mx-auto mb-[60px] flex w-[65vw] flex-col gap-[30px]">
+        <DetailContent />
+        <Table />
+        <SimilarContent />
+      </div>
+    </>
+  );
+}
+export default VulnerabilityDbDetailPage;

--- a/src/components/vulnerability-db/ArticleList.tsx
+++ b/src/components/vulnerability-db/ArticleList.tsx
@@ -1,6 +1,7 @@
 import ArticleListItem from "./ArticleListItem";
 import Buttons from "./Buttons";
 import LockModal from "./LockModal";
+import { ArticleListData } from "./dummydata";
 
 function ArticleList() {
   const isLoggedIn = true;
@@ -12,11 +13,9 @@ function ArticleList() {
         <h1 className="text-lg font-semibold">취약점 DB</h1>
         <Buttons />
         <div className="flex flex-col gap-4 pr-1">
-          {Array(5)
-            .fill({})
-            .map((_item, index) => (
-              <ArticleListItem key={index} />
-            ))}
+          {ArticleListData?.map((item, index) => (
+            <ArticleListItem key={index} {...item} />
+          ))}
         </div>
       </div>
     </div>

--- a/src/components/vulnerability-db/ArticleListItem.tsx
+++ b/src/components/vulnerability-db/ArticleListItem.tsx
@@ -6,7 +6,6 @@ import { TArticleListItem } from "./dummydata";
 function ArticleListItem({
   id,
   title,
-  date,
   label,
   company,
   shortDesc,
@@ -15,16 +14,16 @@ function ArticleListItem({
     <>
       <Link
         href={`/vulnerability-db/${id}`}
-        className="flex h-[235px] flex-col gap-6 rounded-lg border border-[#C3C3C3] p-7"
+        className="border-neutral-20 flex h-[235px] flex-col gap-6 rounded-lg border p-7"
       >
         <div className="flex flex-col gap-2">
           <div className="flex items-center gap-[5px]">
             <Chips>{label}</Chips>
             <h3 className="text-[15px]">{title}</h3>
           </div>
-          <span className="text-[13px] text-[#ADADAD]">{company}</span>
+          <span className="text-neutral-30 text-[13px]">{company}</span>
         </div>
-        <div className="truncate rounded-2xl bg-[#FAF8FF] p-5 text-[13px] text-[#797979]">
+        <div className="bg-background-purpleLight inline-block h-fit truncate rounded-xl px-3 py-2 text-center align-middle text-[13px] text-neutral-50 xl:py-3">
           {shortDesc}
         </div>
         <div className="flex justify-between">
@@ -41,7 +40,7 @@ function ArticleListItem({
               />
             </button>
           </div>
-          <span className="text-[13px] text-[#A2A2A2]">4일 전</span>
+          <span className="text-neutral-30 text-[13px]">4일 전</span>
         </div>
       </Link>
     </>

--- a/src/components/vulnerability-db/ArticleListItem.tsx
+++ b/src/components/vulnerability-db/ArticleListItem.tsx
@@ -1,22 +1,31 @@
 import Image from "next/image";
 import Chips from "./Chips";
+import Link from "next/link";
+import { TArticleListItem } from "./dummydata";
 
-function ArticleListItem() {
+function ArticleListItem({
+  id,
+  title,
+  date,
+  label,
+  company,
+  shortDesc,
+}: TArticleListItem) {
   return (
     <>
-      <div className="flex h-[235px] flex-col gap-6 rounded-lg border border-[#C3C3C3] p-7">
+      <Link
+        href={`/vulnerability-db/${id}`}
+        className="flex h-[235px] flex-col gap-6 rounded-lg border border-[#C3C3C3] p-7"
+      >
         <div className="flex flex-col gap-2">
           <div className="flex items-center gap-[5px]">
-            <Chips>HOT</Chips>
-            <h3 className="text-[15px]">
-              [취약성 경고] Microsoft의 여러 보안 취약점에 대한 CNNVD의 보고서
-            </h3>
+            <Chips>{label}</Chips>
+            <h3 className="text-[15px]">{title}</h3>
           </div>
-          <span className="text-[13px] text-[#ADADAD]">Microsoft</span>
+          <span className="text-[13px] text-[#ADADAD]">{company}</span>
         </div>
         <div className="truncate rounded-2xl bg-[#FAF8FF] p-5 text-[13px] text-[#797979]">
-          최근 Microsoft는 다양한 보안 취약점에 대한 공지를 공식적으로
-          발표했으며, 이 취약점 공지에는 총 80개의 취약점이 있다.
+          {shortDesc}
         </div>
         <div className="flex justify-between">
           <div className="flex gap-3">
@@ -34,7 +43,7 @@ function ArticleListItem() {
           </div>
           <span className="text-[13px] text-[#A2A2A2]">4일 전</span>
         </div>
-      </div>
+      </Link>
     </>
   );
 }

--- a/src/components/vulnerability-db/Buttons.tsx
+++ b/src/components/vulnerability-db/Buttons.tsx
@@ -22,13 +22,13 @@ function Buttons() {
     <>
       <div className="flex gap-3 text-xs">
         <button
-          className={`rounded-full ${click.hot ? "bg-[#FF6D6D] text-white" : "bg-[#E8E8E8] text-[#ADADAD]"} px-3 py-[6px] font-semibold`}
+          className={`rounded-full ${click.hot ? "bg-system-warning text-white" : "bg-neutral-10 text-neutral-40"} px-3 py-[6px] font-semibold`}
           onClick={onClickHot}
         >
           HOT
         </button>
         <button
-          className={`rounded-full ${click.new ? "bg-[#6DB0FF] text-white" : "bg-[#E8E8E8] text-[#ADADAD]"} px-3 py-[6px] font-semibold`}
+          className={`rounded-full ${click.new ? "bg-system-assist text-white" : "bg-neutral-10 text-neutral-40"} px-3 py-[6px] font-semibold`}
           onClick={onClickNew}
         >
           NEW

--- a/src/components/vulnerability-db/Chips.tsx
+++ b/src/components/vulnerability-db/Chips.tsx
@@ -3,7 +3,7 @@ type TChipsProps = React.ComponentPropsWithoutRef<"span">;
 function Chips({ children, ...rest }: TChipsProps) {
   return (
     <div
-      className={`w-fit rounded-full px-2 py-1 text-[11px] font-semibold text-white ${children === "HOT" ? "bg-[#FF6D6D]" : "bg-[#6DB0FF]"}`}
+      className={`w-fit rounded-full px-2 py-1 text-[11px] font-semibold text-white ${children === "HOT" ? "bg-system-warning" : "bg-system-assist"}`}
       {...rest}
     >
       {children}

--- a/src/components/vulnerability-db/Chips.tsx
+++ b/src/components/vulnerability-db/Chips.tsx
@@ -3,7 +3,7 @@ type TChipsProps = React.ComponentPropsWithoutRef<"span">;
 function Chips({ children, ...rest }: TChipsProps) {
   return (
     <div
-      className={`rounded-full px-3 py-[6px] text-xs font-semibold text-white ${children === "HOT" ? "bg-[#FF6D6D]" : "bg-[#6DB0FF]"}`}
+      className={`w-fit rounded-full px-2 py-1 text-[11px] font-semibold text-white ${children === "HOT" ? "bg-[#FF6D6D]" : "bg-[#6DB0FF]"}`}
       {...rest}
     >
       {children}

--- a/src/components/vulnerability-db/LockModal.tsx
+++ b/src/components/vulnerability-db/LockModal.tsx
@@ -8,7 +8,7 @@ function LockModal() {
           <p className="text-lg">자세한 정보를 보고싶다면?</p>
           <Link
             href="/"
-            className="w-[100px] rounded-full border-2 border-[#6100FF] px-6 py-3 text-center text-xl font-light text-[#6100FF]"
+            className="border-primary-500 text-primary-500 w-[100px] rounded-full border-2 px-6 py-3 text-center text-xl font-light"
           >
             Login
           </Link>

--- a/src/components/vulnerability-db/Pagination.tsx
+++ b/src/components/vulnerability-db/Pagination.tsx
@@ -4,7 +4,7 @@ function Pagination() {
   return (
     <>
       <div className="flex justify-center gap-2">
-        {/* <button>
+        {/* <button className="hover:bg-background-purpleLight flex h-9 w-9 items-center justify-center hover:rounded-[4px]">
           <Image
             src={"/images/left-arrow-pagination.png"}
             alt="right"
@@ -17,12 +17,12 @@ function Pagination() {
           .map((item, index) => (
             <button
               key={index}
-              className="h-9 w-9 text-center text-base text-[#3F3F3F] hover:rounded-[4px] hover:bg-[#FAF8FF]"
+              className="text-neutral-80 hover:bg-background-purpleLight h-9 w-9 text-center text-base hover:rounded-[4px]"
             >
               {item + index}
             </button>
           ))}
-        <button className="flex h-9 w-9 items-center justify-center hover:rounded-[4px] hover:bg-[#FAF8FF]">
+        <button className="hover:bg-background-purpleLight flex h-9 w-9 items-center justify-center hover:rounded-[4px]">
           <Image
             src={"/images/right-arrow-pagination.png"}
             alt="right"

--- a/src/components/vulnerability-db/RealTimeTopic.tsx
+++ b/src/components/vulnerability-db/RealTimeTopic.tsx
@@ -3,7 +3,7 @@ function RealTimeTopic() {
     <>
       <div className="flex w-[25%] flex-col gap-4">
         <h1 className="text-lg font-semibold">실시간 Topic</h1>
-        <p className="text-sm text-[#969696]">08.09 18:00 기준</p>
+        <p className="text-neutral-40 text-sm">08.09 18:00 기준</p>
         <div className="rounded-lg border border-[#C3C3C3] p-4">
           <ul>
             {Array(10)
@@ -11,7 +11,7 @@ function RealTimeTopic() {
               .map((item, index) => (
                 <li
                   key={index}
-                  className="border-b border-[#E6E6E6] py-3 text-sm text-[#3F3F3F] first-of-type:font-medium first-of-type:text-[#6100FF] last-of-type:border-none"
+                  className="border-stroke-10 text-neutral-80 first-of-type:text-primary-500 border-b py-3 text-sm first-of-type:font-medium last-of-type:border-none"
                 >
                   {index + 1}. {item.content}
                 </li>

--- a/src/components/vulnerability-db/TopThreeItem.tsx
+++ b/src/components/vulnerability-db/TopThreeItem.tsx
@@ -13,9 +13,6 @@ function TopThreeItem() {
   const [mouseIn, setMouseIn] = useState({ id: 0, state: false });
   const [containerState, setContainerState] = useState(false);
 
-  console.log(containerState);
-  console.log(mouseIn);
-
   const data: TTopThreeData[] = [
     {
       id: 0,

--- a/src/components/vulnerability-db/TopThreeItem.tsx
+++ b/src/components/vulnerability-db/TopThreeItem.tsx
@@ -54,7 +54,7 @@ function TopThreeItem() {
                   {item.title}
                 </h1>
                 <p
-                  className={`${(mouseIn.id === item.id && mouseIn.state) || (item.id === 0 && containerState === false) ? "text-sm" : "text-[8px]"} text-[#969696]`}
+                  className={`${(mouseIn.id === item.id && mouseIn.state) || (item.id === 0 && containerState === false) ? "text-sm" : "text-[8px]"} text-neutral-50`}
                 >
                   {item.date}
                 </p>

--- a/src/components/vulnerability-db/detail/DetailContent.tsx
+++ b/src/components/vulnerability-db/detail/DetailContent.tsx
@@ -1,0 +1,52 @@
+import Chips from "../Chips";
+import Image from "next/image";
+
+function DetailContent() {
+  const content =
+    "최근 Microsoft는 다양한 보안 취약점에 대한 공지를 공식적으로 발표했으며, 이 취약점 공지에는 총 80개의 취약점 패치가 발표되었습니다.  Microsoft Azure 사이트 복구 보안 취약점(CNNVD-202402-1061, CVE-2024-21364), Microsoft Azure Kubernetes 보안 취약점(CNNVD-202402-1050, CVE-2024-21376) 및 기타 취약점을 포함합니다.  위 취약점 악용에 성공한 공격자는 대상 시스템에서 임의 코드를 실행하고, 사용자 데이터를 획득하고, 권한을 상승시키는 등의 작업을 수행할 수 있습니다. 여러 Microsoft 제품 및 시스템이 이 취약점의 영향을 받습니다. 현재 마이크로소프트는 해당 취약점을 수정하기 위한 패치를 공식 출시하였으므로, 사용자들은 해당 취약점의 영향을 받는지 즉시 확인하고 조속히 패치 조치를 취할 것을 권고합니다.    1. 취약점 소개     2024년 2월 13일 Microsoft는 총 80개의 취약점에 대한 패치가 포함된 2024년 2월 보안 업데이트를 출시했습니다. CNNVD에는 이러한 취약점이 포함되어 있습니다. 이 업데이트는 주로 Microsoft Windows 및 Windows 구성 요소, Microsoft Azure Connected Machine Agent, Microsoft Hyper-V, Microsoft Azure, Microsoft Windows USB 직렬 드라이버, Microsoft Exchange Server 등에 적용됩니다. CNNVD는 매우 중요한 취약점 8개, 고위험 취약점 57개, 중간 위험 취약점 15개를 포함한 위험 수준을 평가했습니다. 여러 Microsoft 제품 및 시스템 버전이 이 취약점의 영향을 받습니다. 영향의 구체적인 범위는 Microsoft 공식 웹사이트에서 확인할 수 있습니다. https://portal.msrc.microsoft.com/zh-cn/security-guidance    2. 취약점세부정보     이번 업데이트에는 매우 심각한 취약점 6개, 고위험 취약점 53개, 중간 위험 취약점 14개 등 새로운 취약점에 대한 총 73개의 패치가 포함되어 있습니다.".split(
+      "   ",
+    );
+
+  return (
+    <>
+      <div className="border-neutral-30 flex flex-col gap-3 border-b pb-[30px]">
+        <div className="flex flex-col gap-3">
+          <Chips>HOT</Chips>
+          <h1 className="text-[21px]">
+            [취약성 경고] Microsoft의 여러 보안 취약점에 대한 CNNVD의 보고서
+          </h1>
+        </div>
+        <div className="flex justify-between">
+          <div className="text-neutral-40 flex gap-5 text-sm">
+            <span>취약성 뉴스 세부 정보</span>
+            <span>출시 시간 | 2024.03.08 13:30:24</span>
+          </div>
+          <div className="flex gap-5">
+            <button>
+              <Image src="/images/pin.png" width={18} height={18} alt="pin" />
+            </button>
+            <button>
+              <Image
+                src={"/images/share-box.png"}
+                width={18}
+                height={18}
+                alt="share"
+              />
+            </button>
+          </div>
+        </div>
+      </div>
+      <div className="border-neutral-30 border-b pb-[30px]">
+        <div className="w-full px-2">
+          {content.map((item, index) => (
+            <div key={index}>
+              <br />
+              <div>{item}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}
+export default DetailContent;

--- a/src/components/vulnerability-db/detail/SimilarCard.tsx
+++ b/src/components/vulnerability-db/detail/SimilarCard.tsx
@@ -1,0 +1,47 @@
+import Chips from "../Chips";
+import Image from "next/image";
+
+function SimilarCard() {
+  return (
+    <>
+      <div className="border-neutral-20 w-full rounded-md border p-5">
+        <div className="flex h-[80%] w-full flex-col gap-3">
+          <div className="flex h-[70%] w-full flex-col gap-2">
+            <Chips>HOT</Chips>
+            <h1
+              style={{
+                textOverflow: "ellipsis",
+                overflow: "hidden",
+                display: "-webkit-box",
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: "vertical",
+                lineHeight: "20px",
+              }}
+              className="h-10 w-full text-sm font-medium"
+            >
+              [취약성 경고] Microsoft의 여러 보안 취약점에 대한 CNNVD의 보고서
+            </h1>
+          </div>
+          <span className="text-neutral-40 text-xs">간략한 설명</span>
+        </div>
+        <div className="text-neutral-40 mt-3 flex items-end justify-between text-[10px]">
+          <div className="flex gap-2">
+            <button>
+              <Image src={"/images/pin.png"} width={18} height={18} alt="pin" />
+            </button>
+            <button>
+              <Image
+                src={"/images/share-box.png"}
+                width={18}
+                height={18}
+                alt="share"
+              />
+            </button>
+          </div>
+          <span>2일 전</span>
+        </div>
+      </div>
+    </>
+  );
+}
+export default SimilarCard;

--- a/src/components/vulnerability-db/detail/SimilarContent.tsx
+++ b/src/components/vulnerability-db/detail/SimilarContent.tsx
@@ -1,0 +1,13 @@
+import SimilarContentList from "./SimilarContentList";
+
+function SimilarContent() {
+  return (
+    <>
+      <div className="flex w-full flex-col gap-5">
+        <h1 className="text-lg font-semibold">비슷한 정보글</h1>
+        <SimilarContentList />
+      </div>
+    </>
+  );
+}
+export default SimilarContent;

--- a/src/components/vulnerability-db/detail/SimilarContentList.tsx
+++ b/src/components/vulnerability-db/detail/SimilarContentList.tsx
@@ -1,0 +1,16 @@
+import SimilarCard from "./SimilarCard";
+
+function SimilarContentList() {
+  return (
+    <>
+      <div className="grid grid-cols-3 gap-5">
+        {Array(6)
+          .fill({})
+          .map((_item, index) => (
+            <SimilarCard key={index} />
+          ))}
+      </div>
+    </>
+  );
+}
+export default SimilarContentList;

--- a/src/components/vulnerability-db/detail/Table.tsx
+++ b/src/components/vulnerability-db/detail/Table.tsx
@@ -1,0 +1,27 @@
+import TableBodyTr from "./TableBodyTr";
+import TableHead from "./TableHead";
+
+function Table() {
+  return (
+    <>
+      <div className="border-neutral-20 text-neutral-80 rounded-md border p-[20px]">
+        <table className="w-full table-fixed border-separate border-spacing-[10px]">
+          <thead>
+            <tr className="text-center">
+              <TableHead>일련번호</TableHead>
+              <TableHead>취약점 이름</TableHead>
+              <TableHead>CNNVD 번호</TableHead>
+              <TableHead>공식 링크</TableHead>
+              <TableHead>위험 수준</TableHead>
+              <TableHead>CVE 번호</TableHead>
+            </tr>
+          </thead>
+          <tbody>
+            <TableBodyTr />
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}
+export default Table;

--- a/src/components/vulnerability-db/detail/TableBodyTr.tsx
+++ b/src/components/vulnerability-db/detail/TableBodyTr.tsx
@@ -1,0 +1,23 @@
+function TableBodyTr() {
+  return (
+    <>
+      {Array(10)
+        .fill({})
+        .map((_item, index) => (
+          <tr className="whitespace-wrap text-balance text-center text-[11px]">
+            <td>{index + 1}</td>
+            <td className="text-left">
+              Microsoft Azure 사이트 복구 보안 취약점
+            </td>
+            <td>CNNVD-202402-1061</td>
+            <td>CVE-2024-21364</td>
+            <td>매우 위험함</td>
+            <td className="break-all">
+              https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-21364
+            </td>
+          </tr>
+        ))}
+    </>
+  );
+}
+export default TableBodyTr;

--- a/src/components/vulnerability-db/detail/TableHead.tsx
+++ b/src/components/vulnerability-db/detail/TableHead.tsx
@@ -1,0 +1,12 @@
+type TTableHeadProps = React.ComponentPropsWithoutRef<"span">;
+
+function TableHead({ children }: TTableHeadProps) {
+  return (
+    <th>
+      <span className="border-neutral-80 rounded-full border px-2 py-1 text-[11px]">
+        {children}
+      </span>
+    </th>
+  );
+}
+export default TableHead;

--- a/src/components/vulnerability-db/dummydata.ts
+++ b/src/components/vulnerability-db/dummydata.ts
@@ -1,0 +1,67 @@
+export type TArticleListItem = {
+  id: number;
+  title: string;
+  label: string;
+  company: string;
+  shortDesc: string;
+  description: string;
+  date: string;
+};
+
+export const ArticleListData: TArticleListItem[] = [
+  {
+    id: 1,
+    title: "[취약성 경고] Microsoft의 여러 보안 취약점에 대한 CNNVD의 보고서",
+    label: "HOT",
+    company: "Microsoft",
+    shortDesc:
+      "최근 Microsoft는 다양한 보안 취약점에 대한 공지를 공식적으로 발표했으며, 이 취약점 공지에는 총 80개의 취약점이 있다.",
+    description:
+      "최근 Microsoft는 다양한 보안 취약점에 대한 공지를 공식적으로 발표했으며, 이 취약점 공지에는 총 80개의 취약점 패치가 발표되었습니다. Microsoft Azure 사이트 복구 보안 취약점(CNNVD-202402-1061, CVE-2024-21364), Microsoft Azure Kubernetes 보안 취약점(CNNVD-202402-1050, CVE-2024-21376) 및 기타 취약점을 포함합니다. 위 취약점 악용에 성공한 공격자는 대상 시스템에서 임의 코드를 실행하고, 사용자 데이터를 획득하고, 권한을 상승시키는 등의 작업을 수행할 수 있습니다. 여러 Microsoft 제품 및 시스템이 이 취약점의 영향을 받습니다. 현재 마이크로소프트는 해당 취약점을 수정하기 위한 패치를 공식 출시하였으므로, 사용자들은 해당 취약점의 영향을 받는지 즉시 확인하고 조속히 패치 조치를 취할 것을 권고합니다. 1. 취약점 소개    2024년 2월 13일 Microsoft는 총 80개의 취약점에 대한 패치가 포함된 2024년 2월 보안 업데이트를 출시했습니다. CNNVD에는 이러한 취약점이 포함되어 있습니다. 이 업데이트는 주로 Microsoft Windows 및 Windows 구성 요소, Microsoft Azure Connected Machine Agent, Microsoft Hyper-V, Microsoft Azure, Microsoft Windows USB 직렬 드라이버, Microsoft Exchange Server 등에 적용됩니다. CNNVD는 매우 중요한 취약점 8개, 고위험 취약점 57개, 중간 위험 취약점 15개를 포함한 위험 수준을 평가했습니다. 여러 Microsoft 제품 및 시스템 버전이 이 취약점의 영향을 받습니다. 영향의 구체적인 범위는 Microsoft 공식 웹사이트에서 확인할 수 있습니다. https://portal.msrc.microsoft.com/zh-cn/security-guidance  2. 취약점 세부정보    이번 업데이트에는 매우 심각한 취약점 6개, 고위험 취약점 53개, 중간 위험 취약점 14개 등 새로운 취약점에 대한 총 73개의 패치가 포함되어 있습니다.",
+    date: "2024.03.08 13:30:24",
+  },
+  {
+    id: 2,
+    title: "[취약성 경고] Microsoft의 여러 보안 취약점에 대한 CNNVD의 보고서",
+    label: "HOT",
+    company: "Microsoft",
+    shortDesc:
+      "최근 Microsoft는 다양한 보안 취약점에 대한 공지를 공식적으로 발표했으며, 이 취약점 공지에는 총 80개의 취약점이 있다.",
+    description:
+      "최근 Microsoft는 다양한 보안 취약점에 대한 공지를 공식적으로 발표했으며, 이 취약점 공지에는 총 80개의 취약점 패치가 발표되었습니다. Microsoft Azure 사이트 복구 보안 취약점(CNNVD-202402-1061, CVE-2024-21364), Microsoft Azure Kubernetes 보안 취약점(CNNVD-202402-1050, CVE-2024-21376) 및 기타 취약점을 포함합니다. 위 취약점 악용에 성공한 공격자는 대상 시스템에서 임의 코드를 실행하고, 사용자 데이터를 획득하고, 권한을 상승시키는 등의 작업을 수행할 수 있습니다. 여러 Microsoft 제품 및 시스템이 이 취약점의 영향을 받습니다. 현재 마이크로소프트는 해당 취약점을 수정하기 위한 패치를 공식 출시하였으므로, 사용자들은 해당 취약점의 영향을 받는지 즉시 확인하고 조속히 패치 조치를 취할 것을 권고합니다. 1. 취약점 소개    2024년 2월 13일 Microsoft는 총 80개의 취약점에 대한 패치가 포함된 2024년 2월 보안 업데이트를 출시했습니다. CNNVD에는 이러한 취약점이 포함되어 있습니다. 이 업데이트는 주로 Microsoft Windows 및 Windows 구성 요소, Microsoft Azure Connected Machine Agent, Microsoft Hyper-V, Microsoft Azure, Microsoft Windows USB 직렬 드라이버, Microsoft Exchange Server 등에 적용됩니다. CNNVD는 매우 중요한 취약점 8개, 고위험 취약점 57개, 중간 위험 취약점 15개를 포함한 위험 수준을 평가했습니다. 여러 Microsoft 제품 및 시스템 버전이 이 취약점의 영향을 받습니다. 영향의 구체적인 범위는 Microsoft 공식 웹사이트에서 확인할 수 있습니다. https://portal.msrc.microsoft.com/zh-cn/security-guidance  2. 취약점 세부정보    이번 업데이트에는 매우 심각한 취약점 6개, 고위험 취약점 53개, 중간 위험 취약점 14개 등 새로운 취약점에 대한 총 73개의 패치가 포함되어 있습니다.",
+    date: "2024.03.08 13:30:24",
+  },
+  {
+    id: 3,
+    title: "[취약성 경고] Microsoft의 여러 보안 취약점에 대한 CNNVD의 보고서",
+    label: "HOT",
+    company: "Microsoft",
+    shortDesc:
+      "최근 Microsoft는 다양한 보안 취약점에 대한 공지를 공식적으로 발표했으며, 이 취약점 공지에는 총 80개의 취약점이 있다.",
+    description:
+      "최근 Microsoft는 다양한 보안 취약점에 대한 공지를 공식적으로 발표했으며, 이 취약점 공지에는 총 80개의 취약점 패치가 발표되었습니다. Microsoft Azure 사이트 복구 보안 취약점(CNNVD-202402-1061, CVE-2024-21364), Microsoft Azure Kubernetes 보안 취약점(CNNVD-202402-1050, CVE-2024-21376) 및 기타 취약점을 포함합니다. 위 취약점 악용에 성공한 공격자는 대상 시스템에서 임의 코드를 실행하고, 사용자 데이터를 획득하고, 권한을 상승시키는 등의 작업을 수행할 수 있습니다. 여러 Microsoft 제품 및 시스템이 이 취약점의 영향을 받습니다. 현재 마이크로소프트는 해당 취약점을 수정하기 위한 패치를 공식 출시하였으므로, 사용자들은 해당 취약점의 영향을 받는지 즉시 확인하고 조속히 패치 조치를 취할 것을 권고합니다. 1. 취약점 소개    2024년 2월 13일 Microsoft는 총 80개의 취약점에 대한 패치가 포함된 2024년 2월 보안 업데이트를 출시했습니다. CNNVD에는 이러한 취약점이 포함되어 있습니다. 이 업데이트는 주로 Microsoft Windows 및 Windows 구성 요소, Microsoft Azure Connected Machine Agent, Microsoft Hyper-V, Microsoft Azure, Microsoft Windows USB 직렬 드라이버, Microsoft Exchange Server 등에 적용됩니다. CNNVD는 매우 중요한 취약점 8개, 고위험 취약점 57개, 중간 위험 취약점 15개를 포함한 위험 수준을 평가했습니다. 여러 Microsoft 제품 및 시스템 버전이 이 취약점의 영향을 받습니다. 영향의 구체적인 범위는 Microsoft 공식 웹사이트에서 확인할 수 있습니다. https://portal.msrc.microsoft.com/zh-cn/security-guidance  2. 취약점 세부정보    이번 업데이트에는 매우 심각한 취약점 6개, 고위험 취약점 53개, 중간 위험 취약점 14개 등 새로운 취약점에 대한 총 73개의 패치가 포함되어 있습니다.",
+    date: "2024.03.08 13:30:24",
+  },
+  {
+    id: 4,
+    title: "[취약성 경고] Microsoft의 여러 보안 취약점에 대한 CNNVD의 보고서",
+    label: "HOT",
+    company: "Microsoft",
+    shortDesc:
+      "최근 Microsoft는 다양한 보안 취약점에 대한 공지를 공식적으로 발표했으며, 이 취약점 공지에는 총 80개의 취약점이 있다.",
+    description:
+      "최근 Microsoft는 다양한 보안 취약점에 대한 공지를 공식적으로 발표했으며, 이 취약점 공지에는 총 80개의 취약점 패치가 발표되었습니다. Microsoft Azure 사이트 복구 보안 취약점(CNNVD-202402-1061, CVE-2024-21364), Microsoft Azure Kubernetes 보안 취약점(CNNVD-202402-1050, CVE-2024-21376) 및 기타 취약점을 포함합니다. 위 취약점 악용에 성공한 공격자는 대상 시스템에서 임의 코드를 실행하고, 사용자 데이터를 획득하고, 권한을 상승시키는 등의 작업을 수행할 수 있습니다. 여러 Microsoft 제품 및 시스템이 이 취약점의 영향을 받습니다. 현재 마이크로소프트는 해당 취약점을 수정하기 위한 패치를 공식 출시하였으므로, 사용자들은 해당 취약점의 영향을 받는지 즉시 확인하고 조속히 패치 조치를 취할 것을 권고합니다. 1. 취약점 소개    2024년 2월 13일 Microsoft는 총 80개의 취약점에 대한 패치가 포함된 2024년 2월 보안 업데이트를 출시했습니다. CNNVD에는 이러한 취약점이 포함되어 있습니다. 이 업데이트는 주로 Microsoft Windows 및 Windows 구성 요소, Microsoft Azure Connected Machine Agent, Microsoft Hyper-V, Microsoft Azure, Microsoft Windows USB 직렬 드라이버, Microsoft Exchange Server 등에 적용됩니다. CNNVD는 매우 중요한 취약점 8개, 고위험 취약점 57개, 중간 위험 취약점 15개를 포함한 위험 수준을 평가했습니다. 여러 Microsoft 제품 및 시스템 버전이 이 취약점의 영향을 받습니다. 영향의 구체적인 범위는 Microsoft 공식 웹사이트에서 확인할 수 있습니다. https://portal.msrc.microsoft.com/zh-cn/security-guidance  2. 취약점 세부정보    이번 업데이트에는 매우 심각한 취약점 6개, 고위험 취약점 53개, 중간 위험 취약점 14개 등 새로운 취약점에 대한 총 73개의 패치가 포함되어 있습니다.",
+    date: "2024.03.08 13:30:24",
+  },
+  {
+    id: 5,
+    title: "[취약성 경고] Microsoft의 여러 보안 취약점에 대한 CNNVD의 보고서",
+    label: "HOT",
+    company: "Microsoft",
+    shortDesc:
+      "최근 Microsoft는 다양한 보안 취약점에 대한 공지를 공식적으로 발표했으며, 이 취약점 공지에는 총 80개의 취약점이 있다.",
+    description:
+      "최근 Microsoft는 다양한 보안 취약점에 대한 공지를 공식적으로 발표했으며, 이 취약점 공지에는 총 80개의 취약점 패치가 발표되었습니다. Microsoft Azure 사이트 복구 보안 취약점(CNNVD-202402-1061, CVE-2024-21364), Microsoft Azure Kubernetes 보안 취약점(CNNVD-202402-1050, CVE-2024-21376) 및 기타 취약점을 포함합니다. 위 취약점 악용에 성공한 공격자는 대상 시스템에서 임의 코드를 실행하고, 사용자 데이터를 획득하고, 권한을 상승시키는 등의 작업을 수행할 수 있습니다. 여러 Microsoft 제품 및 시스템이 이 취약점의 영향을 받습니다. 현재 마이크로소프트는 해당 취약점을 수정하기 위한 패치를 공식 출시하였으므로, 사용자들은 해당 취약점의 영향을 받는지 즉시 확인하고 조속히 패치 조치를 취할 것을 권고합니다. 1. 취약점 소개    2024년 2월 13일 Microsoft는 총 80개의 취약점에 대한 패치가 포함된 2024년 2월 보안 업데이트를 출시했습니다. CNNVD에는 이러한 취약점이 포함되어 있습니다. 이 업데이트는 주로 Microsoft Windows 및 Windows 구성 요소, Microsoft Azure Connected Machine Agent, Microsoft Hyper-V, Microsoft Azure, Microsoft Windows USB 직렬 드라이버, Microsoft Exchange Server 등에 적용됩니다. CNNVD는 매우 중요한 취약점 8개, 고위험 취약점 57개, 중간 위험 취약점 15개를 포함한 위험 수준을 평가했습니다. 여러 Microsoft 제품 및 시스템 버전이 이 취약점의 영향을 받습니다. 영향의 구체적인 범위는 Microsoft 공식 웹사이트에서 확인할 수 있습니다. https://portal.msrc.microsoft.com/zh-cn/security-guidance  2. 취약점 세부정보    이번 업데이트에는 매우 심각한 취약점 6개, 고위험 취약점 53개, 중간 위험 취약점 14개 등 새로운 취약점에 대한 총 73개의 패치가 포함되어 있습니다.",
+    date: "2024.03.08 13:30:24",
+  },
+];


### PR DESCRIPTION
## 🚨 관련 이슈

#12 

## 🚀 작업 내용

- 상세 페이지 dummy 데이터 추가 및 링크 설정
- 상세 페이지 detail content 섹션 퍼블리싱
- 상세 페이지 비슷한 정보글 섹션 퍼블리싱
- 상세 페이지 table 섹션 퍼블리싱
- 기존에 hex 코드로 지정했던 색상을 테마 색상 적용하여 수정


## 🖼️ 스크린샷
<img width="1507" alt="detail contents 섹션" src="https://github.com/user-attachments/assets/4037dbba-0918-4eb8-bb7f-91de608ffd50">

<img width="1507" alt="table 섹션" src="https://github.com/user-attachments/assets/a6b07145-1c07-4aa7-97f7-416e1c8f9e75">

<img width="1501" alt="비슷한 정보글 섹션" src="https://github.com/user-attachments/assets/20c669e8-136a-4aa5-999e-8e996e8eb719">



## ✅ 이후 계획

- 개인 정보 처리 방침 페이지 퍼블리싱
- 서비스 이용약관 페이지 퍼블리싱
