### PR TITLE
feat : 코드 검사 결과 페이지 퍼블리싱

### DIFF
--- a/src/app/me/(analyze)/ai-analyze/page.tsx
+++ b/src/app/me/(analyze)/ai-analyze/page.tsx
@@ -1,0 +1,35 @@
+import Image from "next/image";
+import leftVioletArrow from "../../../../../public/images/left-violet-arrow.png";
+import { analysisResults } from "../data";
+import FileAnalysisSideBar from "@/components/analyze/ai-analyze/FileAnalysisSideBar";
+import FileAnalysisList from "@/components/analyze/ai-analyze/FileAnalysisList";
+
+/**
+ * `AiAnalyzePage` 컴포넌트는 파일 분석 페이지를 렌더링합니다.
+ * 페이지 상단에는 페이지 제목과 아이콘이 포함되어 있으며,
+ * 사이드바에는 파일 목록이 표시되고, 본문에는 코드와 분석 결과가 나타납니다.
+ *
+ * @returns JSX.Element - 페이지 구성 요소.
+ */
+function AiAnalyzePage() {
+  return (
+    <div className="container mx-auto flex min-w-[1760px] flex-col gap-[45px]">
+      {/* 페이지 헤더 */}
+      <section className="flex h-[79px] w-full items-center gap-6 rounded-full border-4 border-primary-500 p-5 text-primary-500">
+        <Image
+          src={leftVioletArrow}
+          alt="Left Violet Arrow"
+          width={36}
+          height={36}
+        />
+        <p className="flex items-center text-[38px] font-medium">sfacweb - 1</p>
+      </section>
+      <section className="flex gap-8">
+        <FileAnalysisSideBar analysisResults={analysisResults} />
+        <FileAnalysisList analysisResults={analysisResults} />
+      </section>
+    </div>
+  );
+}
+
+export default AiAnalyzePage;

--- a/src/app/me/(analyze)/analyze/page.tsx
+++ b/src/app/me/(analyze)/analyze/page.tsx
@@ -2,24 +2,28 @@ import Image from "next/image";
 import leftVioletArrow from "../../../../../public/images/left-violet-arrow.png";
 import AnalysisWrapper from "@/components/analyze/AnalysisWrapper";
 
+/**
+ * `AnalyzePage` 컴포넌트는 분석 페이지의 레이아웃을 구성합니다.
+ * 페이지 상단에는 헤더가 포함되어 있으며, 분석 콘텐츠를 래핑하는 `AnalysisWrapper` 컴포넌트를 렌더링합니다.
+ *
+ * @returns {JSX.Element} - 분석 페이지 구성 요소
+ */
 async function AnalyzePage() {
   return (
-    <>
-      <div className="container mx-auto flex min-w-[1760px] flex-col gap-[45px]">
-        <section className="flex h-[79px] w-full items-center gap-6 rounded-full border-4 border-primary-500 p-5 text-primary-500">
-          <Image
-            src={leftVioletArrow}
-            alt="Left Violet Arrow"
-            width={36}
-            height={36}
-          />
-          <p className="flex items-center text-[38px] font-medium">
-            sfacweb - 1
-          </p>
-        </section>
-        <AnalysisWrapper />
-      </div>
-    </>
+    <div className="container mx-auto flex min-w-[1760px] flex-col gap-[45px]">
+      {/* 헤더 섹션 */}
+      <header className="flex h-[79px] w-full items-center gap-6 rounded-full border-4 border-primary-500 p-5 text-primary-500">
+        <Image
+          src={leftVioletArrow}
+          alt="Left Violet Arrow"
+          width={36}
+          height={36}
+        />
+        <h1 className="text-[38px] font-medium">sfacweb - 1</h1>
+      </header>
+      {/* 분석 콘텐츠 */}
+      <AnalysisWrapper />
+    </div>
   );
 }
 export default AnalyzePage;

--- a/src/app/me/(analyze)/data.ts
+++ b/src/app/me/(analyze)/data.ts
@@ -1,6 +1,6 @@
-import { TRepositoryFiles } from "./type";
+import { TAnalysisResult, TFile } from "./type";
 
-export let fileData: TRepositoryFiles[] = [
+export let fileData: TFile[] = [
   {
     id: "1",
     fileName: "file1.txt",
@@ -966,5 +966,274 @@ export default function Home() {
           </CardHeader>
         </Card>
         <Card className="bg-transparent backdrop-blur-sm"> `,
+  },
+];
+
+export let analysisResults: TAnalysisResult[] = [
+  {
+    id: "1",
+    fileName: "file1.txt",
+    code: `
+import SectionBusinessForever from "@/components/section-business-forever";
+import SectionVideoDisplayer from "@/components/section-video-displayer";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import Image from "next/image";
+
+export default function Home() {
+  return (
+    <main className="flex flex-col items-center py-36 min-h-screen"
+    // only background brightness is 0.5
+      style={{ background: "linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('/bg.svg')", backgroundSize: "cover", backgroundPosition: "center"}}>
+      <hgroup className="flex flex-col items-center py-16 gap-4 z-10">
+        <Badge>Systemable</Badge>
+        <h1 className="text-6xl font-bold">Build once, Business forever</h1>
+        <p className="text-sm">
+          We help businesses to grow and scale by providing them with the right
+          tools and resources.
+        </p>
+      </hgroup>
+      <div className="z-10 grid grid-cols-2 max-w-4xl mx-auto gap-4 my-24">
+        <Card className="bg-transparent backdrop-blur-sm col-span-2">
+          <CardHeader>
+            <CardTitle>Analyze</CardTitle>
+            <CardDescription>
+              We analyze your business processes and provide you with the right ways to make sure your business is running smoothly.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+        <Card className="bg-transparent backdrop-blur-sm">
+          <CardHeader>
+            <CardTitle>Systemize</CardTitle>
+            <CardDescription>
+              We find the ways to systemize your business processes to make sure you are not wasting time on repetitive tasks.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+        <Card className="bg-transparent backdrop-blur-sm"> `,
+
+    results: [
+      {
+        code: "color:#333;",
+        coment:
+          "컬러 코드를 설정할 때 이렇게 하면 *** 오류 발생 확률이 높아집니다.",
+      },
+      {
+        code: "import {Badge} from '@/components/ui/badge';",
+        coment: "*** 오류 발생 확률이 높은 코드입니다.",
+      },
+    ],
+  },
+  {
+    id: "2",
+    fileName: "file2.txt",
+    code: `
+import SectionBusinessForever from "@/components/section-business-forever";
+import SectionVideoDisplayer from "@/components/section-video-displayer";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import Image from "next/image";
+
+export default function Home() {
+  return (
+    <main className="flex flex-col items-center py-36 min-h-screen"
+    // only background brightness is 0.5
+      style={{ background: "linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('/bg.svg')", backgroundSize: "cover", backgroundPosition: "center"}}>
+      <hgroup className="flex flex-col items-center py-16 gap-4 z-10">
+        <Badge>Systemable</Badge>
+        <h1 className="text-6xl font-bold">Build once, Business forever</h1>
+        <p className="text-sm">
+          We help businesses to grow and scale by providing them with the right
+          tools and resources.
+        </p>
+      </hgroup>
+      <div className="z-10 grid grid-cols-2 max-w-4xl mx-auto gap-4 my-24">
+        <Card className="bg-transparent backdrop-blur-sm col-span-2">
+          <CardHeader>
+            <CardTitle>Analyze</CardTitle>
+            <CardDescription>
+              We analyze your business processes and provide you with the right ways to make sure your business is running smoothly.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+        <Card className="bg-transparent backdrop-blur-sm">
+          <CardHeader>
+            <CardTitle>Systemize</CardTitle>
+            <CardDescription>
+              We find the ways to systemize your business processes to make sure you are not wasting time on repetitive tasks.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+        <Card className="bg-transparent backdrop-blur-sm"> `,
+    results: [
+      {
+        code: "color:#333;",
+        coment:
+          "컬러 코드를 설정할 때 이렇게 하면 *** 오류 발생 확률이 높아집니다.",
+      },
+      {
+        code: "import {Badge} from '@/components/ui/badge';",
+        coment: "*** 오류 발생 확률이 높은 코드입니다.",
+      },
+    ],
+  },
+  {
+    id: "3",
+    fileName: "file3.txt",
+    code: `
+import SectionBusinessForever from "@/components/section-business-forever";
+import SectionVideoDisplayer from "@/components/section-video-displayer";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import Image from "next/image";
+
+export default function Home() {
+  return (
+    <main className="flex flex-col items-center py-36 min-h-screen"
+    // only background brightness is 0.5
+      style={{ background: "linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('/bg.svg')", backgroundSize: "cover", backgroundPosition: "center"}}>
+      <hgroup className="flex flex-col items-center py-16 gap-4 z-10">
+        <Badge>Systemable</Badge>
+        <h1 className="text-6xl font-bold">Build once, Business forever</h1>
+        <p className="text-sm">
+          We help businesses to grow and scale by providing them with the right
+          tools and resources.
+        </p>
+      </hgroup>
+      <div className="z-10 grid grid-cols-2 max-w-4xl mx-auto gap-4 my-24">
+        <Card className="bg-transparent backdrop-blur-sm col-span-2">
+          <CardHeader>
+            <CardTitle>Analyze</CardTitle>
+            <CardDescription>
+              We analyze your business processes and provide you with the right ways to make sure your business is running smoothly.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+        <Card className="bg-transparent backdrop-blur-sm">
+          <CardHeader>
+            <CardTitle>Systemize</CardTitle>
+            <CardDescription>
+              We find the ways to systemize your business processes to make sure you are not wasting time on repetitive tasks.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+        <Card className="bg-transparent backdrop-blur-sm"> `,
+    results: [
+      {
+        code: "color:#333;",
+        coment:
+          "컬러 코드를 설정할 때 이렇게 하면 *** 오류 발생 확률이 높아집니다.",
+      },
+      {
+        code: "import {Badge} from '@/components/ui/badge';",
+        coment: "*** 오류 발생 확률이 높은 코드입니다.",
+      },
+    ],
+  },
+  {
+    id: "4",
+    fileName: "file4.txt",
+    code: `
+import SectionBusinessForever from "@/components/section-business-forever";
+import SectionVideoDisplayer from "@/components/section-video-displayer";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import Image from "next/image";
+
+export default function Home() {
+  return (
+    <main className="flex flex-col items-center py-36 min-h-screen"
+    // only background brightness is 0.5
+      style={{ background: "linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('/bg.svg')", backgroundSize: "cover", backgroundPosition: "center"}}>
+      <hgroup className="flex flex-col items-center py-16 gap-4 z-10">
+        <Badge>Systemable</Badge>
+        <h1 className="text-6xl font-bold">Build once, Business forever</h1>
+        <p className="text-sm">
+          We help businesses to grow and scale by providing them with the right
+          tools and resources.
+        </p>
+      </hgroup>
+      <div className="z-10 grid grid-cols-2 max-w-4xl mx-auto gap-4 my-24">
+        <Card className="bg-transparent backdrop-blur-sm col-span-2">
+          <CardHeader>
+            <CardTitle>Analyze</CardTitle>
+            <CardDescription>
+              We analyze your business processes and provide you with the right ways to make sure your business is running smoothly.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+        <Card className="bg-transparent backdrop-blur-sm">
+          <CardHeader>
+            <CardTitle>Systemize</CardTitle>
+            <CardDescription>
+              We find the ways to systemize your business processes to make sure you are not wasting time on repetitive tasks.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+        <Card className="bg-transparent backdrop-blur-sm"> `,
+    results: [
+      {
+        code: "color:#333;",
+        coment:
+          "컬러 코드를 설정할 때 이렇게 하면 *** 오류 발생 확률이 높아집니다.",
+      },
+      {
+        code: "import {Badge} from '@/components/ui/badge';",
+        coment: "*** 오류 발생 확률이 높은 코드입니다.",
+      },
+    ],
+  },
+  {
+    id: "5",
+    fileName: "file5.txt",
+    code: `
+import SectionBusinessForever from "@/components/section-business-forever";
+import SectionVideoDisplayer from "@/components/section-video-displayer";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import Image from "next/image";
+
+export default function Home() {
+  return (
+    <main className="flex flex-col items-center py-36 min-h-screen"
+    // only background brightness is 0.5
+      style={{ background: "linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('/bg.svg')", backgroundSize: "cover", backgroundPosition: "center"}}>
+      <hgroup className="flex flex-col items-center py-16 gap-4 z-10">
+        <Badge>Systemable</Badge>
+        <h1 className="text-6xl font-bold">Build once, Business forever</h1>
+        <p className="text-sm">
+          We help businesses to grow and scale by providing them with the right
+          tools and resources.
+        </p>
+      </hgroup>
+      <div className="z-10 grid grid-cols-2 max-w-4xl mx-auto gap-4 my-24">
+        <Card className="bg-transparent backdrop-blur-sm col-span-2">
+          <CardHeader>
+            <CardTitle>Analyze</CardTitle>
+            <CardDescription>
+              We analyze your business processes and provide you with the right ways to make sure your business is running smoothly.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+        <Card className="bg-transparent backdrop-blur-sm">
+          <CardHeader>
+            <CardTitle>Systemize</CardTitle>
+            <CardDescription>
+              We find the ways to systemize your business processes to make sure you are not wasting time on repetitive tasks.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+        <Card className="bg-transparent backdrop-blur-sm"> `,
+    results: [
+      {
+        code: "color:#333;",
+        coment:
+          "컬러 코드를 설정할 때 이렇게 하면 *** 오류 발생 확률이 높아집니다.",
+      },
+      {
+        code: "import {Badge} from '@/components/ui/badge';",
+        coment: "*** 오류 발생 확률이 높은 코드입니다.",
+      },
+    ],
   },
 ];

--- a/src/app/me/(analyze)/type.ts
+++ b/src/app/me/(analyze)/type.ts
@@ -1,13 +1,20 @@
-export type TRepositoryFiles = {
+export type TFile = {
   id: string;
   fileName: string;
   code: string;
 };
 
-export type TSelectedFiles = TRepositoryFiles & { isCodeAnalyzed?: string };
+export type TSelectedFiles = TFile & { isCodeAnalyzed?: string };
 // isCodeAnalyzed : completed(완료), pending(대기), error(오류)
 
 export type TSelectedFilesProps = {
   selectedFiles: TSelectedFiles[];
   onClick: (file: TSelectedFiles) => void;
+};
+
+export type TAnalysisResult = TFile & {
+  results: {
+    code: string;
+    coment: string;
+  }[];
 };

--- a/src/components/analyze/AnalysisWrapper.tsx
+++ b/src/components/analyze/AnalysisWrapper.tsx
@@ -3,18 +3,30 @@ import { useState } from "react";
 import { fileData } from "@/app/me/(analyze)/data";
 import { TSelectedFiles } from "@/app/me/(analyze)/type";
 import ProgressList from "./ProgressList";
-import FileList from "./FileList";
 import CodeArea from "./CodeArea";
+import FileSideBar from "./FileSideBar";
 
+/**
+ * `AnalysisWrapper` 컴포넌트
+ *
+ * 이 컴포넌트는 파일 분석을 관리하고 UI를 렌더링합니다.
+ * 파일 선택, 전체 선택, 선택된 파일에 대한 코드 표시 및 분석 대기 중 상태를 처리합니다.
+ *
+ * @returns {JSX.Element} `AnalysisWrapper` 컴포넌트
+ */
 export default function AnalysisWrapper() {
   const [selectedFiles, setSelectedFiles] = useState<TSelectedFiles[]>([]);
 
-  // 파일 선택
+  /**
+   * 파일 선택 핸들러
+   * @param {TSelectedFiles} file - 선택하거나 해제할 파일
+   */
   const handleToggleFiles = (file: TSelectedFiles) => {
     setSelectedFiles((prev) => {
       const fileIndex = prev.findIndex((f) => f.id === file.id);
 
       if (fileIndex === -1) {
+        // 파일을 추가
         return [
           ...prev,
           {
@@ -25,17 +37,25 @@ export default function AnalysisWrapper() {
           },
         ];
       } else {
+        // 파일을 제거
         return prev.filter((f) => f.id !== file.id);
       }
     });
   };
-  // 폴더 전체 선택
+
+  /**
+   * 전체 파일 선택 핸들러
+   */
   const handleSelectAllFiles = () => {
-    let allFiles = fileData.map((file) => {
-      return { ...file, isCodeAnalyzed: "pending" };
-    });
+    const allFiles = fileData.map((file) => ({
+      ...file,
+      isCodeAnalyzed: "pending",
+    }));
     setSelectedFiles(allFiles);
   };
+
+  // 마지막 선택된 파일을 변수로 저장
+  const lastSelectedFile = selectedFiles[selectedFiles.length - 1];
 
   return (
     <>
@@ -52,16 +72,20 @@ export default function AnalysisWrapper() {
         />
       </section>
       <main className="flex h-[1163px] w-full min-w-[1760px] justify-between gap-7">
-        <FileList
+        <FileSideBar
           selectedFiles={selectedFiles}
           onClick={handleToggleFiles}
           fileData={fileData}
         />
-        <section className="flex gap-[28px]">
-          <CodeArea type="select" selectedFiles={selectedFiles} />
-          <CodeArea type="analyze" selectedFiles={selectedFiles} />
+        <section className="flex w-full gap-[28px]">
+          <CodeArea type="select" fileCode={lastSelectedFile?.code || ""} />
+          <CodeArea type="analyze" fileCode={lastSelectedFile?.code || ""} />
         </section>
       </main>
+      {/* 
+      검사 확인, 검사 상태 모달 들어갈 예정
+     <Modal />
+     */}
     </>
   );
 }

--- a/src/components/analyze/CodeArea.tsx
+++ b/src/components/analyze/CodeArea.tsx
@@ -2,46 +2,88 @@ import Image from "next/image";
 import magnifier from "../../../public/images/magnifier.png";
 import folderDashed from "../../../public/images/folder-dashed.png";
 import bugImg from "../../../public/images/bug.svg";
+import reload from "../../../public/images/reload.png";
 
-import { TSelectedFiles } from "@/app/me/(analyze)/type";
+const MESSAGES = {
+  visible: "파일을 선택하세요",
+  hidden: "분석할 파일이 없어요!",
+};
+const ICONS = {
+  visible: magnifier,
+  hidden: folderDashed,
+};
+const ALT_TEXT = {
+  visible: "Magnifier",
+  hidden: "Folder Dashed",
+};
+const ANALYZE_TYPE = (
+  <div className="absolute top-1/2 z-20 flex flex-col items-center justify-center gap-11">
+    <Image src={bugImg} alt="Bug" width={79} height={81} />
+    <span className="text-[32px] font-bold">분석 대기중</span>
+  </div>
+);
 
+/**
+ * `TCodeAreaProps` 타입 정의
+ * @typedef {Object} TCodeAreaProps
+ * @property {string} type - 코드 영역의 상태를 나타냅니다.
+ *   - `select`: 파일이 선택된 상태
+ *   - `analyze`: 분석 대기 중인 상태
+ * @property {string} fileCode - 출력할 파일 코드 부분입니다.
+ */
 export type TCodeAreaProps = {
   type: string;
-  selectedFiles: TSelectedFiles[];
+  fileCode: string;
 };
 
-export default function CodeArea({ type, selectedFiles }: TCodeAreaProps) {
-  let text = type === "select" ? "파일을 선택하세요" : "분석할 파일이 없어요!";
-  let codeAlt = type === "select" ? "Magnifier" : "Folder Dashed";
-  let Icon = type === "select" ? magnifier : folderDashed;
-  let color = type === "select" ? "text-primary-500" : "";
-  let code =
-    selectedFiles.length > 0
-      ? selectedFiles[selectedFiles.length - 1].code
-      : "";
-  let isSelected = selectedFiles.length > 0;
-  let blur = type !== "select" ? "blur-sm" : "";
+/**
+ * 코드 영역을 표시하는 컴포넌트입니다.
+ * - `type`이 `"select"`일 경우: 파일 선택된 상태를 나타내는 추가 내용을 렌더링합니다.
+ * - `type`이 `"analyze"`일 경우: 분석 대기 중 상태를 나타내는 추가 내용을 렌더링합니다.
+ *
+ * @param {TCodeAreaProps} props - 컴포넌트의 프로퍼티
+ * @param {string} props.type - 코드 영역의 상태를 나타냅니다.
+ * @param {string} props.fileCode - 출력할 파일 코드 부분입니다.
+ *
+ * @returns {JSX.Element} 코드 영역 컴포넌트
+ */
+
+const CodeArea = ({ type, fileCode }: TCodeAreaProps) => {
+  const text = type === "select" ? MESSAGES.visible : MESSAGES.hidden;
+  const codeAlt = type === "select" ? ALT_TEXT.visible : ALT_TEXT.hidden;
+  const Icon = ICONS[type === "select" ? "visible" : "hidden"];
+  const color = type === "select" ? "text-primary-500" : "";
+  const code = fileCode || "";
+  const isSelected = Boolean(fileCode);
+  const isAnalyzed = type !== "select" ? "blur-sm" : "";
 
   return (
-    <>
-      <div className="min-y-[976px] flex min-w-[730px] flex-col items-center justify-center gap-8 rounded-lg border-[1px] border-[#C3C3C3]">
-        {isSelected ? (
-          <div className="relative flex items-center justify-center">
-            {type !== "select" && (
-              <div className="left absolute z-20 flex flex-col items-center justify-center gap-11">
-                <Image src={bugImg} alt="Bug" width={79} height={81} />
-                <span className="text-[32px] font-bold">분석 대기중</span>
-              </div>
-            )}
-            <p className={blur}>{code}</p>
+    <div
+      className={`${!isSelected && "justify-center"} flex h-[976px] w-1/2 flex-col items-center gap-8 rounded-lg border-[1px] border-[#C3C3C3] px-10 py-11`}
+    >
+      {isSelected ? (
+        // 파일 선택
+        <div className="relative flex flex-col items-center justify-center gap-10">
+          {type === "analyze" && ANALYZE_TYPE}
+          <div
+            className={`${isAnalyzed} flex flex-col items-center justify-center gap-6`}
+          >
+            <Image src={reload} alt="Success" width={44} height={44} />
+            <div className="gap flex h-[50px] w-[550px] justify-center rounded-lg border-[1px] border-primary-500 bg-[#F2EBFF] p-3 text-center text-xl font-[600] text-primary-500">
+              취약성 검사 코드
+            </div>
           </div>
-        ) : (
-          <>
-            <Image src={Icon} alt={codeAlt} width={48} height={48} />
-            <span className={`text-[32px] font-[500] ${color}`}>{text}</span>
-          </>
-        )}
-      </div>
-    </>
+          <p className={isAnalyzed}>{code}</p>
+        </div>
+      ) : (
+        // 파일 미선택
+        <>
+          <Image src={Icon} alt={codeAlt} width={48} height={48} />
+          <span className={`text-[32px] font-[500] ${color}`}>{text}</span>
+        </>
+      )}
+    </div>
   );
-}
+};
+
+export default CodeArea;

--- a/src/components/analyze/FileList.tsx
+++ b/src/components/analyze/FileList.tsx
@@ -1,84 +1,39 @@
-import Image from "next/image";
-import xMarkError from "../../../public/images/x-mark-error.png";
-import triangleYellow from "../../../public/images/triangle-yellow.png";
-import circleGreen from "../../../public/images/circle-green.png";
-import menuRepoFolder from "../../../public/images/menu-repo-folder.png";
 import FileListItem from "./FileListItem";
-import { TRepositoryFiles, TSelectedFiles } from "@/app/me/(analyze)/type";
+import { TFileListProps } from "./FileSideBar";
 
-export type TFileListProps = {
-  onClick: (file: TSelectedFiles) => void;
-  fileData: TRepositoryFiles[];
-  selectedFiles : TSelectedFiles[]
-};
-
-export default function FileList({ onClick, fileData, selectedFiles }: TFileListProps) {
+/**
+ * `FileList` 컴포넌트는 파일 목록을 렌더링합니다.
+ * 각 파일 항목은 선택 상태에 따라 스타일이 적용되며,
+ * 사용자가 항목을 클릭할 때 지정된 콜백 함수가 호출됩니다.
+ *
+ * @param {Object} props - 컴포넌트 속성
+ * @param {Function} props.onClick - 파일 클릭 시 호출되는 콜백 함수
+ * @param {TFile[]} props.fileData - 파일 데이터 배열
+ * @param {TSelectedFiles[]} props.selectedFiles - 선택된 파일 목록
+ * @returns {JSX.Element} - 파일 목록 구성 요소
+ */
+export default function FileList({
+  onClick,
+  fileData,
+  selectedFiles,
+}: TFileListProps) {
   return (
     <>
-      <aside className="flex h-[1163px] w-[247px] flex-col justify-between">
-        <div className="flex h-[65px] w-[246px] justify-evenly gap-6 rounded-lg border-[1px] border-[#C3C3C3] p-5">
-          <div className="flex w-[44px] items-center justify-center gap-2 text-xl">
-            <Image src={xMarkError} alt="Error" width={18} height={18} />
-            {12}
-          </div>
-          <p className="flex w-[44px] items-center justify-center gap-2 text-xl">
-            <Image src={triangleYellow} alt="Error" width={23} height={20} />
-            {8}
-          </p>
-          <p className="flex w-[44px] items-center justify-center gap-2 text-xl">
-            <Image src={circleGreen} alt="Error" width={22} height={22} />
-            {23}
-          </p>
-        </div>
-        {/* 프로필 */}
-        <div className="h-[994px] w-[247px] scroll-smooth rounded-xl border-[1px] border-[#C3C3C3]">
-          <div className="flex h-[70px] justify-between rounded-t-xl bg-primary-50 p-5">
-            <div className="flex items-center gap-[10px] text-xl">
-              <img
-                className="rounded-full"
-                src="https://img1.daumcdn.net/thumb/R1280x0/?fname=http://t1.daumcdn.net/brunch/service/user/7r5X/image/9djEiPBPMLu_IvCYyvRPwmZkM1g.jpg"
-                alt="Profile Image"
-                width={30}
-                height={30}
-              />
-              <p>testProfile</p>
-            </div>
-            <div className="flex items-center">
-              <Image
-                src={menuRepoFolder}
-                width={14}
-                height={6.5}
-                alt="Menu Repo Folder"
-              />
-            </div>
-          </div>
-          {/* 파일 목록 */}
-          <ul className="h-[924px] overflow-y-auto">
-            {fileData.map((file) => {
-              // 'let'을 사용하여 변수를 선언하고 값을 설정합니다
-              const isSelected = selectedFiles.some(
-                (selectedFile) => selectedFile.id === file.id,
-              );
-            console.log(isSelected);
-              // JSX를 반환합니다
-              return (
-                <FileListItem
-                  key={file.id} // 각 항목에 고유한 key를 추가합니다
-                  isSelected={isSelected} // 변수 이름을 'isSelected'로 수정
-                  file={file}
-                  onClick={onClick}
-                />
-              );
-            })}
-          </ul>
-        </div>
-        <button
-          className="fill-radius-8px-lg w-[246px] text-xl"
-          onClick={() => alert("검사하기")}
-        >
-          검사하기
-        </button>
-      </aside>
+      <ul className="h-[924px] overflow-y-auto">
+        {fileData.map((file) => {
+          const isSelected = selectedFiles.some(
+            (selectedFile) => selectedFile.id === file.id,
+          );
+          return (
+            <FileListItem
+              key={file.id}
+              isSelected={isSelected}
+              file={file}
+              onClick={onClick}
+            />
+          );
+        })}
+      </ul>
     </>
   );
 }

--- a/src/components/analyze/FileListItem.tsx
+++ b/src/components/analyze/FileListItem.tsx
@@ -1,31 +1,35 @@
-import { TRepositoryFiles, TSelectedFiles } from "@/app/me/(analyze)/type";
+import { TFile, TSelectedFiles } from "@/app/me/(analyze)/type";
 import fileImg from "../../../public/images/file.png";
 import checkImg from "../../../public/images/check.png";
 import Image from "next/image";
-type TFileListItem = {
-  file: TRepositoryFiles;
+
+type TFileListItemProps = {
+  file: TFile;
   isSelected: boolean;
   onClick: (file: TSelectedFiles) => void;
 };
-export default function FileListItem({
-  file,
-  isSelected,
-  onClick,
-}: TFileListItem) {
-  return (
-    <>
-      <li
-        key={file.id}
-        onClick={() => onClick(file)}
-        className={`${isSelected && "bg-[#E3E1E7]"} border-1 flex h-[44px] gap-1 border-[1px] border-[#E6E6E6] p-[10px] hover:cursor-pointer hover:bg-[#E3E1E7]`}
-      >
-        {isSelected && (
-          <Image src={checkImg} alt="Check" width={24} height={24} />
-        )}
-        <Image src={fileImg} alt="File" width={24} height={24} />
 
-        {file.fileName}
-      </li>
-    </>
+/**
+ * FileListItem 컴포넌트는 파일 항목을 렌더링하며, 선택 상태와 클릭 핸들러를 지원합니다.
+ * @param {TFileListItemProps} props - 컴포넌트 속성
+ * @param {TFile} props.file - 파일 정보 객체
+ * @param {boolean} props.isSelected - 항목의 선택 상태
+ * @param {(file: TSelectedFiles) => void} props.onClick - 클릭 이벤트 핸들러
+ */
+function FileListItem({ file, isSelected, onClick }: TFileListItemProps) {
+  return (
+    <li
+      onClick={() => onClick(file)}
+      className={`flex h-[44px] cursor-pointer items-center gap-2 border border-[#E6E6E6] p-2 ${
+        isSelected ? "bg-[#E3E1E7]" : "hover:bg-[#E3E1E7]"
+      }`}
+    >
+      {isSelected && (
+        <Image src={checkImg} alt="Selected" width={24} height={24} />
+      )}
+      <Image src={fileImg} alt="File" width={24} height={24} />
+      <span className="text-base text-[#3F3F3F]">{file.fileName}</span>
+    </li>
   );
 }
+export default FileListItem;

--- a/src/components/analyze/FileSideBar.tsx
+++ b/src/components/analyze/FileSideBar.tsx
@@ -1,0 +1,79 @@
+import Image from "next/image";
+import xMarkError from "../../../public/images/x-mark-error.png";
+import triangleYellow from "../../../public/images/triangle-yellow.png";
+import circleGreen from "../../../public/images/circle-green.png";
+import menuRepoFolder from "../../../public/images/menu-repo-folder.png";
+import { TFile, TSelectedFiles } from "@/app/me/(analyze)/type";
+import StateItem from "./StateItem";
+import FileList from "./FileList";
+
+export type TFileListProps = {
+  onClick: (file: TSelectedFiles) => void;
+  fileData: TFile[];
+  selectedFiles: TSelectedFiles[];
+};
+
+/**
+ * `FileSideBar` 컴포넌트는 사이드바를 렌더링하며, 통계와 프로필, 파일 목록을 포함합니다.
+ * 통계는 상태 항목을 표시하고, 프로필 영역과 파일 목록이 하위 요소로 포함됩니다.
+ *
+ * @param {Object} props - 컴포넌트 속성
+ * @param {Function} props.onClick - 파일 클릭 시 호출되는 콜백 함수
+ * @param {TFile[]} props.fileData - 파일 데이터 배열
+ * @param {TSelectedFiles[]} props.selectedFiles - 선택된 파일 목록
+ * @returns {JSX.Element} - 사이드바 구성 요소
+ */
+export default function FileSideBar({
+  onClick,
+  fileData,
+  selectedFiles,
+}: TFileListProps) {
+  return (
+    <>
+      <aside className="flex h-[1163px] w-[247px] flex-col justify-between">
+        {/* 통계 */}
+        <div className="flex h-[65px] w-[246px] justify-evenly gap-6 rounded-lg border-[1px] border-[#C3C3C3] p-5">
+          <StateItem src={xMarkError} alt="Error" count={12} />
+          <StateItem src={triangleYellow} alt="Warning" count={8} />
+          <StateItem src={circleGreen} alt="Success" count={23} />
+        </div>
+
+        {/* 프로필 */}
+        <div className="h-[994px] w-[247px] scroll-smooth rounded-xl border-[1px] border-[#C3C3C3]">
+          <div className="flex h-[70px] justify-between rounded-t-xl bg-primary-50 p-5">
+            <div className="flex items-center gap-[10px] text-xl">
+              <img
+                className="rounded-full"
+                src="https://img1.daumcdn.net/thumb/R1280x0/?fname=http://t1.daumcdn.net/brunch/service/user/7r5X/image/9djEiPBPMLu_IvCYyvRPwmZkM1g.jpg"
+                alt="Profile Image"
+                width={30}
+                height={30}
+              />
+              <p>testProfile</p>
+            </div>
+            <div className="flex items-center">
+              <Image
+                src={menuRepoFolder}
+                width={14}
+                height={6.5}
+                alt="Menu Repo Folder"
+              />
+            </div>
+          </div>
+          {/* 파일 목록 */}
+          <FileList
+            fileData={fileData}
+            onClick={onClick}
+            selectedFiles={selectedFiles}
+          />
+        </div>
+        <button
+          className="fill-radius-8px-lg w-[246px] text-xl"
+          onClick={() => alert("검사하기")}
+        >
+          검사하기
+        </button>
+      </aside>
+    </>
+  );
+}

--- a/src/components/analyze/Infobox.tsx
+++ b/src/components/analyze/Infobox.tsx
@@ -1,0 +1,49 @@
+import Image from "next/image";
+import circleSuccess from "../../../public/images/circle-success.png";
+import triangleYellow from "../../../public/images/triangle-yellow.png";
+
+type TInfoboxProps = {
+  code: string;
+  coment: string;
+};
+
+/**
+ * Infobox 컴포넌트는 분석 결과를 보여주는 박스입니다.
+ * @param {Object[]} results - 분석 결과 배열
+ * @param {string} results[].code - 코드 텍스트
+ * @param {string} results[].coment - 주석 텍스트
+ */
+function Infobox({ results }: { results: TInfoboxProps[] }) {
+  return (
+    <div className="flex h-[976px] w-1/2 flex-col items-center gap-8 rounded-lg border border-[#00C308] p-10">
+      <div className="flex flex-col items-center gap-6">
+        <Image src={circleSuccess} alt="Success" width={44} height={44} />
+        <div className="flex h-[50px] w-[550px] items-center justify-center rounded-lg border border-[#00C308] bg-[#E5F8E5] p-3 text-center text-xl font-semibold text-[#00C308]">
+          분석완료
+        </div>
+      </div>
+      <ul className="flex w-full flex-col gap-6 overflow-y-auto">
+        {results.map((result, idx) => (
+          <li
+            key={idx}
+            className="flex flex-col gap-3 rounded-lg bg-[#f5f5f5] p-5"
+          >
+            <div className="flex items-center gap-2">
+              <Image
+                src={triangleYellow}
+                alt="Triangle Indicator"
+                width={18}
+                height={18}
+              />
+              <p className="text-[18px] font-semibold text-[#525252]">
+                {result.code}
+              </p>
+            </div>
+            <p className="text-[16px] text-[#3F3F3F]">{result.coment}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+export default Infobox;

--- a/src/components/analyze/InputChips.tsx
+++ b/src/components/analyze/InputChips.tsx
@@ -3,6 +3,14 @@ import fileImg from "../../../public/images/file.png";
 import closeImg from "../../../public/images/x-mark-off.png";
 
 type TProgressBarProps = React.ComponentPropsWithoutRef<"button">;
+/**
+ * `InputChips` 컴포넌트는 파일 이름을 표시하고 닫기 버튼을 포함하는 사용자 인터페이스 요소를 렌더링합니다.
+ * 이 컴포넌트는 버튼 역할을 하며, 전달된 속성과 자식 요소를 포함합니다.
+ *
+ * @param {React.ButtonHTMLAttributes<HTMLButtonElement>} props - 컴포넌트에 전달되는 속성
+ * @param {React.ReactNode} props.children - 버튼에 표시할 내용
+ * @returns {JSX.Element} - 렌더링된 버튼 컴포넌트
+ */
 export default function InputChips({ children, ...rest }: TProgressBarProps) {
   return (
     <>

--- a/src/components/analyze/ProgressBar.tsx
+++ b/src/components/analyze/ProgressBar.tsx
@@ -1,14 +1,26 @@
-export default function ProgressBar({ progress }: { progress: number }) {
+import React from "react";
+
+type TProgressBarProps = {
+  /** 진행 상태를 나타내는 숫자 (0부터 100까지의 값) */
+  progress: number;
+};
+
+/**
+ * ProgressBar 컴포넌트는 진행 상태를 시각적으로 표시하는 프로그레스 바입니다.
+ * @param {ProgressBarProps} props - 컴포넌트 속성
+ * @param {number} props.progress - 프로그레스 바의 진행 상태 (0~100)
+ * @returns {JSX.Element} 프로그레스 바 컴포넌트
+ */
+function ProgressBar({ progress }: TProgressBarProps) {
   return (
-    <>
-      <div className="h-[14px] w-full gap-6 rounded-full bg-gray-200">
-        <div
-          className="flex h-[14px] items-center justify-center rounded-full bg-[#00C308] p-0.5 text-center text-sm font-semibold leading-none text-blue-100"
-          style={{ width: `${progress}%` }}
-        >
-          {progress}%
-        </div>
+    <div className="h-[14px] w-full rounded-full bg-gray-200">
+      <div
+        className="flex h-full items-center justify-center rounded-full bg-[#00C308] text-center text-sm font-semibold text-blue-100"
+        style={{ width: `${progress}%` }}
+      >
+        {progress}%
       </div>
-    </>
+    </div>
   );
 }
+export default ProgressBar;

--- a/src/components/analyze/ProgressList.tsx
+++ b/src/components/analyze/ProgressList.tsx
@@ -2,33 +2,47 @@ import { TSelectedFilesProps } from "@/app/me/(analyze)/type";
 import InputChips from "./InputChips";
 import ProgressBar from "./ProgressBar";
 
+/**
+ * `ProgressList` 컴포넌트는 파일 목록과 진행 상황을 시각적으로 표시합니다.
+ *
+ * - `selectedFiles`: 현재 선택된 파일들의 배열입니다.
+ * - `onClick`: 파일을 클릭할 때 호출되는 핸들러 함수입니다.
+ *
+ * 컴포넌트는 선택된 파일들을 표시하고, 진행 바를 통해 파일 분석 진행 상태를 나타냅니다.
+ *
+ * @param {TSelectedFilesProps} props - 컴포넌트에 전달되는 속성들.
+ * @param {TSelectedFiles[]} props.selectedFiles - 선택된 파일의 배열.
+ * @param {(file: TSelectedFiles) => void} props.onClick - 파일 클릭 시 호출되는 핸들러 함수.
+ * @returns {JSX.Element} - 렌더링된 컴포넌트.
+ */
 export default function ProgressList({
   selectedFiles,
   onClick,
-}: TSelectedFilesProps) {
-  let progess =
+}: TSelectedFilesProps): JSX.Element {
+  // 진행률 계산
+  const progress =
     (selectedFiles.filter((file) => file.isCodeAnalyzed !== "Success").length /
       selectedFiles.length) *
     100;
-  let testProgress = 45;
+
+  // 테스트용 진행도
+  const testProgress = 45;
+
   return (
-    <>
-      <div>
-        <div className="h-[107px] w-[1484px] gap-5 rounded-lg border-[1px] border-primary-100 p-5">
-          <div
-            className="mb-4 flex h-[35px] w-[1444px] gap-7 overflow-x-auto"
-            style={{ overflowX: "hidden" }}
-          >
-            {selectedFiles &&
-              selectedFiles.map((file) => (
-                <InputChips onClick={() => onClick(file)} key={file.id}>
-                  {file.fileName}
-                </InputChips>
-              ))}
-          </div>
-          <ProgressBar progress={testProgress} />
+    <div>
+      <div className="h-[107px] w-[1484px] gap-5 rounded-lg border-[1px] border-primary-100 p-5">
+        <div
+          className="mb-4 flex h-[35px] w-[1444px] gap-7 overflow-x-auto"
+          style={{ overflowX: "hidden" }}
+        >
+          {selectedFiles.map((file) => (
+            <InputChips onClick={() => onClick(file)} key={file.id}>
+              {file.fileName}
+            </InputChips>
+          ))}
         </div>
+        <ProgressBar progress={testProgress} />
       </div>
-    </>
+    </div>
   );
 }

--- a/src/components/analyze/StateItem.tsx
+++ b/src/components/analyze/StateItem.tsx
@@ -1,0 +1,28 @@
+import Image, { StaticImageData } from "next/image";
+
+/**
+ * 통계 항목을 표시하는 컴포넌트입니다.
+ *
+ * @param {string} src - 이미지 소스 URL.
+ * @param {string} alt - 이미지 대체 텍스트.
+ * @param {number} count - 표시할 카운트 숫자.
+ * @returns {JSX.Element} - 렌더링된 통계 항목.
+ */
+export default function StateItem({
+  src,
+  alt,
+  count,
+}: {
+  src: StaticImageData;
+  alt: string;
+  count: number;
+}) {
+  return (
+    <>
+      <div className="flex w-[44px] items-center justify-center gap-2 text-xl">
+        <Image src={src} alt={alt} width={24} height={24} />
+        {count}
+      </div>
+    </>
+  );
+}

--- a/src/components/analyze/ai-analyze/FileAnalysisItem.tsx
+++ b/src/components/analyze/ai-analyze/FileAnalysisItem.tsx
@@ -1,0 +1,37 @@
+import Image from "next/image";
+import CodeArea from "../CodeArea";
+import Infobox from "../Infobox";
+import folderOpenImg from "../../../../public/images/folder-open.png";
+
+/**
+ * `FileAnalysisItem` 컴포넌트는 단일 파일의 분석 결과를 표시합니다.
+ * 파일 이름, 코드, 그리고 분석 결과를 포함하여 렌더링합니다.
+ *
+ * @param {Object} props - 컴포넌트 속성
+ * @param {string} props.fileName - 파일 이름
+ * @param {string} props.code - 파일 코드
+ * @param {Object[]} props.results - 분석 결과 배열
+ * @returns {JSX.Element} - 파일 분석 항목 구성 요소
+ */
+export default function FileAnalysisItem({
+  fileName,
+  code,
+  results,
+}: {
+  fileName: string;
+  code: string;
+  results: { code: string; coment: string }[];
+}): JSX.Element {
+  return (
+    <li className="flex w-full flex-col gap-3 rounded-lg">
+      <div className="flex h-[40px] items-center gap-3 rounded-lg text-[23px]">
+        <Image src={folderOpenImg} alt="Folder Open" width={30} height={30} />
+        <span>{`sfacweb-1/${fileName}`}</span>
+      </div>
+      <div className="flex w-full gap-7">
+        <CodeArea type="select" fileCode={code} />
+        <Infobox results={results} />
+      </div>
+    </li>
+  );
+}

--- a/src/components/analyze/ai-analyze/FileAnalysisList.tsx
+++ b/src/components/analyze/ai-analyze/FileAnalysisList.tsx
@@ -1,0 +1,34 @@
+import { TAnalysisResult } from "@/app/me/(analyze)/type";
+import FileAnalysisItem from "./FileAnalysisItem";
+
+/**
+ * `FileAnalysisList` 컴포넌트는 주어진 분석 결과 배열을 기반으로
+ * 파일별 분석 결과를 나열합니다.
+ * 각 파일의 이름, 코드, 분석 결과를 포함하는 항목들을 렌더링합니다.
+ *
+ * @param {Object} props - 컴포넌트 속성
+ * @param {TAnalysisResult[]} props.analysisResults - 분석 결과 배열
+ * @returns {JSX.Element} - 파일 분석 리스트 구성 요소
+ */
+export default function FileAnalysisList({
+  analysisResults,
+}: {
+  analysisResults: TAnalysisResult[];
+}) {
+  return (
+    <>
+      <main>
+        <ul className="flex flex-col gap-8">
+          {analysisResults.map((result: TAnalysisResult) => (
+            <FileAnalysisItem
+              key={result.id}
+              fileName={result.fileName}
+              code={result.code}
+              results={result.results}
+            />
+          ))}
+        </ul>
+      </main>
+    </>
+  );
+}

--- a/src/components/analyze/ai-analyze/FileAnalysisSideBar.tsx
+++ b/src/components/analyze/ai-analyze/FileAnalysisSideBar.tsx
@@ -1,0 +1,35 @@
+import { TAnalysisResult } from "@/app/me/(analyze)/type";
+import Image from "next/image";
+import fileImg from "../../../../public/images/file.png";
+
+/**
+ * `FileAnalysisSideBar` 컴포넌트는 사이드바에 분석 파일 목록을 표시합니다.
+ * 각 파일은 아이콘과 함께 파일 이름이 나열됩니다.
+ *
+ * @param {Object} props - 컴포넌트 속성
+ * @param {TAnalysisResult[]} props.analysisResults - 분석 결과 배열
+ * @returns {JSX.Element} - 사이드바 파일 목록 구성 요소
+ */
+export default function FileAnalysisSideBar({
+  analysisResults,
+}: {
+  analysisResults: TAnalysisResult[];
+}) {
+  return (
+    <>
+      <aside>
+        <ul className="w-[247px] rounded-sm">
+          {analysisResults.map((result: TAnalysisResult) => (
+            <li
+              key={result.id}
+              className="flex h-[44px] gap-1 border-[1px] border-t-0 border-[#C3C3C3] p-2 first:rounded-t-md first:border-t last:rounded-b-md"
+            >
+              <Image src={fileImg} alt="File" width={24} height={24} />
+              <span>{result.fileName}</span>
+            </li>
+          ))}
+        </ul>
+      </aside>
+    </>
+  );
+}


### PR DESCRIPTION
## 🚨 관련 이슈
#6 
#20 

## 🚀 작업 내용
- 코드 검사 결과 페이지 퍼블리싱
    -  코드 검사 결과 페이지 코드 목록 사이드바 섹션 퍼블리싱
    -  코드 검사 결과 페이지 선택한 코드 섹션 퍼블리싱
    -  코드 검사 결과 페이지 분석된 결과 섹션 퍼블리싱
- 코드 검사 페이지 컴포넌트 및 Props 주석 추가

## 📝 참고 사항(선택)


## 🖼️ 스크린샷(선택)
-  ![화면 캡처 2024-08-16 203938](https://github.com/user-attachments/assets/fba0f54b-e67c-4d4b-b08d-78c7a200c59c)
- 코드 검사 결과를 어떻게 주는지 몰라서 일단 figma에 나오는 결과값 가지고 퍼블리싱 했습니다. 서버에서 주는 값에 따라서 분석 결과 화면이 달라질 것 같습니다.



## ✅ 이후 계획(선택)

- 모달창 코드 검사 비동기 처리 퍼블리싱 작업
- llama3 서버 코드 공부
- 깃허브 연동 후 레저피토리 불러오는 방법 공부 
