### PR TITLE
feat: 모달 컨테이너 생성

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "next": "14.2.5",
     "react": "^18",
     "react-dom": "^18",
-    "swiper": "^11.1.9"
+    "swiper": "^11.1.9",
+    "zustand": "^4.5.5"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from "next/font/google";
 import "@/css/globals.css";
 import Gnb from "@/components/common/Gnb";
 import Footer from "@/components/common/Footer";
+import ModalProvider from "@/components/modal/ModalProvider";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -19,8 +20,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>
+      <body className="relative">
         <Gnb />
+        <ModalProvider />
         {children}
         <Footer />
       </body>

--- a/src/components/landing/CardArticle.tsx
+++ b/src/components/landing/CardArticle.tsx
@@ -2,7 +2,7 @@ import CardList from "./card/CardList";
 
 function CardArticle() {
   return (
-    <section className="relative z-10 h-[1280px] overflow-hidden bg-primary-500 pt-36">
+    <section className="z-10 h-[1280px] overflow-hidden bg-primary-500 pt-36">
       <div className="flex h-[1025px] flex-col items-center justify-center gap-[121px]">
         <h2 className="text-center text-6xl font-bold leading-[80px] text-white">
           안전과 보호를 우선으로 하는

--- a/src/components/modal/ModalContainer.tsx
+++ b/src/components/modal/ModalContainer.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import useOutsideClick from "@/hook/useOutSideClick";
+import useModal from "@/store/modalState";
+import { useEffect, useRef } from "react";
+
+function ModalContainer() {
+  const modalRef = useRef(null);
+  useOutsideClick(modalRef);
+  const { ModalContent } = useModal();
+
+  useEffect(() => {
+    const $body = document.querySelector("body");
+
+    if (!$body) {
+      throw new Error("body element is not found");
+    }
+
+    //모달창 스크롤 막기
+    const { overflow } = $body.style;
+    $body.style.overflow = "hidden";
+    return () => {
+      $body.style.overflow = overflow;
+    };
+  }, []);
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-gray-800 bg-opacity-50">
+      <div ref={modalRef} className="rounded-lg bg-white p-6 shadow-lg">
+        {ModalContent ? <ModalContent /> : null}
+      </div>
+    </div>
+  );
+}
+export default ModalContainer;

--- a/src/components/modal/ModalProvider.tsx
+++ b/src/components/modal/ModalProvider.tsx
@@ -1,0 +1,25 @@
+"use client";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import ModalContainer from "./ModalContainer";
+import useModal from "@/store/modalState";
+
+const ModalProvider = () => {
+  const [mounted, setMounted] = useState(false);
+  const { isOpen } = useModal();
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  return (
+    <>
+      {mounted &&
+        isOpen &&
+        typeof document !== "undefined" &&
+        createPortal(<ModalContainer />, document.body)}
+    </>
+  );
+};
+
+export default ModalProvider;

--- a/src/hook/useOutSideClick.ts
+++ b/src/hook/useOutSideClick.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import useModal from "@/store/modalState";
+import { useEffect, RefObject } from "react";
+/**
+ * @param ref 모달의 내부 컴포넌트 부분을 등록하면 외부 클릭시 모달 닫히도록 설정 가능
+ */
+const useOutsideClick = <T extends HTMLElement = HTMLElement>(
+  ref: RefObject<T>,
+) => {
+  const { setIsClose } = useModal();
+  useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        setIsClose?.();
+      }
+    };
+
+    window.addEventListener("mousedown", handleClick);
+
+    return () => window.removeEventListener("mousedown", handleClick);
+  }, [ref]);
+};
+
+export default useOutsideClick;

--- a/src/store/modalState.tsx
+++ b/src/store/modalState.tsx
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { FC } from "react";
 
-interface ModalState {
+type ModalState = {
   isOpen?: boolean;
   ModalContent?: FC<any>;
   props?: { [key: string]: any };
@@ -9,7 +9,7 @@ interface ModalState {
   setIsOpen?: () => void;
   setIsClose?: () => void;
   setModalContent?: (value: FC<any>) => void;
-}
+};
 
 function InitialContent() {
   return <div>오류입니다. 모달 콘텐츠를 입력해주세요</div>;

--- a/src/store/modalState.tsx
+++ b/src/store/modalState.tsx
@@ -1,0 +1,39 @@
+import { create } from "zustand";
+import { FC } from "react";
+
+interface ModalState {
+  isOpen?: boolean;
+  ModalContent?: FC<any>;
+  props?: { [key: string]: any };
+  setProps: (prop: object) => void;
+  setIsOpen?: () => void;
+  setIsClose?: () => void;
+  setModalContent?: (value: FC<any>) => void;
+}
+
+function InitialContent() {
+  return <div>오류입니다. 모달 콘텐츠를 입력해주세요</div>;
+}
+/**
+ * 모달 상태를 관리하는 커스텀 훅.
+ * @param {boolean} isOpen - 모달이 열려 있는지 여부.
+ * @param {React.FC<any>} ModalContent - (모달을 열 시 필수!)모달 내부 FunctionComponent 또는 JSX
+ * @param {Object} props - 외부에서 모달에 전해 줄 내용.
+ * @param {Function} setProps - 모달에 대한 추가 속성을 설정하는 함수.
+ * @param {Function} setIsOpen - 모달을 여는 함수.
+ * @param {Function} setIsClose - 모달을 닫고 내용을 초기화하는 함수.
+ * @param {Function} setModalContent - 모달의 내용을 설정하는 함수.
+ */
+
+const useModal = create<ModalState>((set) => ({
+  isOpen: false,
+  ModalContent: InitialContent,
+  props: {},
+  setProps: (prop) => set(() => ({ props: prop })),
+  setIsOpen: () => set(() => ({ isOpen: true })),
+  setIsClose: () =>
+    set(() => ({ isOpen: false, ModalContent: InitialContent, props: {} })),
+  setModalContent: (value: FC<any>) => set(() => ({ ModalContent: value })),
+}));
+
+export default useModal;


### PR DESCRIPTION
## 🚨 관련 이슈
#26 
## 🚀 작업 내용
- 모달 컨테이너 생성
- 모달 최상단에 띄우기 위한 provider 생성
- 모달 상태 관리를 위한 zustand 파일 생성(/store/modalState.tsx)

## 📝 참고 사항
- 컨테이너만 구현되어있습니다
- 그래서 모달 내부에 넣을 내용만 컴포넌트로 구현 => useModal 훅으로 컴포넌트를 전달

### 1. 모달 내부 컴포넌트 생성 (이런식으로 만들었다고 치면)
```typescript
import useModal from "@/store/modalState";

function TestComponent() {
  // useModal 훅으로 바깥에서 전해준 props 내용 가져오기 가능
  const { props } = useModal();
  return (
    <div>
      Test모달내부
      <div>{props && props.name}</div>
    </div>
  );
}
export default TestComponent;

```
### 2.  모달 호출하기 (버튼을 누르면 모달을 띄운다고 가정)
```typescript
"use client";

import useModal from "@/store/modalState";
import TestComponent from "./TestComponent";

function TestButton() {
  // 모달 관련된 상태는 모두 useModal 을 이용하면 됩니다.
  const { setIsOpen, setModalContent, setProps }: any = useModal();

  const handlerButton = () => {
    setIsOpen();  // 모달 열기
    setModalContent(TestComponent);  //컴포넌트 전달
    setProps({ name: "프롭스입니다" });  //따로 전해줄 값이 있다면 자유롭게 객체로 전달
  };

  return (
    <button onClick={handlerButton} className="fill-radius-8px-lg">
      TestButton
    </button>
  );
}
export default TestButton;

```
### 모달 관련 상태
```typescript
(아래 중 필요한 상태만 가져와서 사용하시면 돼요!)
isOpen -  {boolean} 모달이 열려 있는지 여부.
ModalContent - {React.FC<any>} (모달을 열 시 필수!) 모달 컨테이너 내부에 들어갈 컴포넌트
props - {Object}  외부에서 모달에 전해 줄 내용.
setProps -  {Function} 모달에 대한 추가 속성을 설정하는 함수.
setIsOpen -  {Function} 모달을 여는 함수.
setIsClose - {Function} 모달을 닫고 내용을 초기화하는 함수.
setModalContent -  {Function} 모달의 내용을 설정하는 함수.
```

## 🖼️ 스크린샷(선택)
![image](https://github.com/user-attachments/assets/07a38f69-412c-4c45-92b1-55459521f6be)




## ✅ 이후 계획(선택)
- 공용 인풋

## 개발자 질문
- 중첩 모달이 필요할까요..? => stack구조로 수정
- 모달 내부에서 바깥으로 값을 보내야 할 상황이 있을까요 => 흠...
- 모달 내부에서 처리 할 로직이 많을까요? => promise로 모아서 처리하도록 변경
- 다른 좋은 방법 있을까요..?
