### PR TITLE
github OAuth 연동, firebase 설치 및 초기세팅, 사용자 정보 fireStore 등록

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,14 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+        port: "",
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
+    "firebase": "^10.13.0",
     "next": "14.2.5",
+    "next-auth": "^5.0.0-beta.20",
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.52.2",

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,2 @@
+import { handlers } from "@/auth";
+export const { GET, POST } = handlers;

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -3,6 +3,9 @@ import Credentials from "next-auth/providers/credentials";
 import github from "next-auth/providers/github";
 
 export const authConfig = {
+  session: {
+    maxAge: 24 * 60 * 60,
+  },
   callbacks: {
     authorized({ auth, request: { nextUrl } }) {
       // null 값을 명시적으로 false로 표시하기 위해 이중부정을 사용한다.

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -1,0 +1,33 @@
+import type { NextAuthConfig } from "next-auth";
+import Credentials from "next-auth/providers/credentials";
+import github from "next-auth/providers/github";
+
+export const authConfig = {
+  callbacks: {
+    authorized({ auth, request: { nextUrl } }) {
+      // null 값을 명시적으로 false로 표시하기 위해 이중부정을 사용한다.
+      const isLoggedIn = !!auth?.user;
+      const isOnDashboard = nextUrl.pathname.startsWith("/me");
+      if (isOnDashboard) {
+        if (isLoggedIn) {
+          return true;
+        }
+        // Redirect unauthenticated users to login page
+        return false;
+      }
+      return true;
+    },
+  },
+  providers: [
+    // 일반 로그인 로직 및 유효성 검사
+    Credentials({}),
+    // github OAuth
+    github({
+      clientId: process.env.NEXT_PUBLIC_AUTH_GITHUB_ID,
+      clientSecret: process.env.NEXT_PUBLIC_AUTH_GITHUB_SECRET,
+    }),
+  ],
+  pages: {
+    signIn: "/login",
+  },
+} satisfies NextAuthConfig;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,6 @@
+import NextAuth from "next-auth";
+import { authConfig } from "./auth.config";
+
+export const { handlers, auth, signIn, signOut } = NextAuth({
+  ...authConfig,
+});

--- a/src/components/common/Gnb.tsx
+++ b/src/components/common/Gnb.tsx
@@ -1,12 +1,16 @@
 import Image from "next/image";
 import Link from "next/link";
 import bug from "/public/images/Bug.svg";
+import { logout } from "@/server/user.action";
+import { getSession } from "@/lib/getSession";
 
 /**
  * @TODO 로그인 처리
  * @TODO 글꼴 폰트 적용 및 공용색상 사용으로 변경하기
  */
-function Gnb() {
+async function Gnb() {
+  const session = await getSession();
+
   return (
     <>
       <div className={`px-20 py-6`}>
@@ -20,7 +24,16 @@ function Gnb() {
             </Link>
             <Link href="/vulnerability-db">취약점 DB</Link>
           </div>
-          <Link href="/me">MY 저장소</Link>
+          <div className="flex items-center gap-10">
+            <Link href="/me">MY 저장소</Link>
+            {session !== null && (
+              <form action={logout}>
+                <button type="submit" className="out-radius-999px px-4 py-2">
+                  Logout
+                </button>
+              </form>
+            )}
+          </div>
         </div>
       </div>
     </>

--- a/src/components/landing/head-article/LoginButton.tsx
+++ b/src/components/landing/head-article/LoginButton.tsx
@@ -1,3 +1,4 @@
+import { getSession } from "@/lib/getSession";
 import Link from "next/link";
 
 /**
@@ -5,14 +6,27 @@ import Link from "next/link";
  *
  * @returns {JSX.Element} 로그인 페이지로 이동하는 버튼을 렌더링하는 JSX 요소를 반환합니다.
  */
-function LoginButton() {
+async function LoginButton() {
+  const session = await getSession();
+
   return (
-    <Link
-      href="/login"
-      className="flex h-14 items-center justify-center gap-2.5 rounded-full bg-primary-500 px-6 py-4 text-[28px] font-light text-white"
-    >
-      Login
-    </Link>
+    <>
+      {session !== null ? (
+        <Link
+          href="/me"
+          className="flex h-14 items-center justify-center gap-2.5 rounded-full bg-primary-500 px-6 py-4 text-[28px] font-light text-white"
+        >
+          파일 분석하러 가기
+        </Link>
+      ) : (
+        <Link
+          href="/login"
+          className="flex h-14 items-center justify-center gap-2.5 rounded-full bg-primary-500 px-6 py-4 text-[28px] font-light text-white"
+        >
+          Login
+        </Link>
+      )}
+    </>
   );
 }
 export default LoginButton;

--- a/src/components/login/GithubLogin.tsx
+++ b/src/components/login/GithubLogin.tsx
@@ -1,27 +1,51 @@
-"use client";
-
 import Image from "next/image";
 import githubImg from "/public/images/github.svg";
+import { github } from "@/server/user.action";
+import { getSession } from "@/lib/getSession";
+import { redirect } from "next/navigation";
+import { addDoc, collection, getDocs, query, where } from "firebase/firestore";
+import db from "@/firebase/firebaseClient";
+
 /**
  * `GithubLogin` 컴포넌트는 GitHub 소셜 로그인을 위한 버튼을 렌더링합니다.
  * 사용자가 버튼을 클릭하면 GitHub 로그인 기능이 실행될 예정입니다.
  * 현재 `onClick` 핸들러는 빈 함수로 정의되어 있으며,
  * 실제 GitHub 로그인 기능은 추후 구현 예정입니다.
  *
- * @TODO 깃허브 로그인 기능 연결
- *
  * @returns {JSX.Element} GitHub 로그인 버튼을 렌더링하는 JSX 요소를 반환합니다.
  */
-function GithubLogin() {
-  const onClick = () => {};
+async function GithubLogin() {
+  const session = await getSession();
+  console.log(JSON.stringify(session));
+
+  // 로그인 되면 랜딩페이지로 이동
+  if (session !== null) {
+    const docRef = collection(db, "users");
+
+    const q = query(docRef, where("email", "==", session.user?.email));
+    const isRegistered = (await getDocs(q)).docs[0]?.data();
+
+    if (!isRegistered) {
+      await addDoc(docRef, {
+        username: session.user?.name,
+        email: session.user?.email,
+        profileImg: session.user?.image,
+      });
+    }
+
+    redirect("/");
+  }
+
   return (
-    <button
-      onClick={onClick}
-      className="inline-flex h-14 items-center justify-center gap-2.5 rounded-[999px] bg-[#6100ff] px-6 py-4 text-center font-['Inter'] text-[28px] font-light text-white"
-    >
-      <Image src={githubImg} alt="githubImg" width={40} height={40} />
-      Github로 연동 로그인하기
-    </button>
+    <form action={github}>
+      <button
+        type="submit"
+        className="inline-flex h-14 items-center justify-center gap-2.5 rounded-[999px] bg-[#6100ff] px-6 py-4 text-center font-['Inter'] text-[28px] font-light text-white"
+      >
+        <Image src={githubImg} alt="githubImg" width={40} height={40} />
+        Github로 연동 로그인하기
+      </button>
+    </form>
   );
 }
 export default GithubLogin;

--- a/src/firebase/firebaseClient.ts
+++ b/src/firebase/firebaseClient.ts
@@ -1,0 +1,17 @@
+import { initializeApp } from "firebase/app";
+import { getFirestore } from "firebase/firestore";
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_NEXT_PUBLIC_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_APP_ID,
+  measurementId: process.env.NEXT_PUBLIC_MEASUREMENT_ID,
+};
+
+const app = initializeApp(firebaseConfig);
+const db = getFirestore(app);
+
+export default db;

--- a/src/lib/getSession.ts
+++ b/src/lib/getSession.ts
@@ -1,0 +1,6 @@
+import { auth } from "@/auth";
+
+export const getSession = async () => {
+  const session = await auth();
+  return session;
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,9 @@
+import NextAuth from "next-auth";
+import { authConfig } from "./auth.config";
+
+export default NextAuth(authConfig).auth;
+
+export const config = {
+  // https://nextjs.org/docs/app/building-your-application/routing/middleware#matcher
+  matcher: ["/((?!api|_next/static|_next/image|.*\\.png$).*)"],
+};

--- a/src/server/user.action.ts
+++ b/src/server/user.action.ts
@@ -1,0 +1,11 @@
+"use server";
+
+import { signIn, signOut } from "@/auth";
+
+export async function logout() {
+  await signOut();
+}
+
+export async function github() {
+  await signIn("github");
+}


### PR DESCRIPTION
## 🚨 관련 이슈

#39

## 🚀 작업 내용

-  로그인 시 계정 정보 가져오기 확인
- 로그인 시 랜딩페이지(’/’)로 리다이렉트 처리
- 헤더에 Logout 버튼 조건부 렌더링 처리
- 랜딩페이지에 ‘파일분석하러가기’ 조건부 렌더링 처리
- 로그아웃 처리
- firebase DB 설정
- firebase user 정보 등록
- nextAuth 세션 유효기간 24시간으로 변경

## 🖼️ 스크린샷

<img width="985" alt="로그인 후 랜딩 페이지" src="https://github.com/user-attachments/assets/389fd572-6bd1-49ce-afa6-302bd419acb9">


## ✅ 이후 계획

- github API 사용하여 repo 불러오기
- zustand store에 로그인 정보 등록
