### PR TITLE
feat : 코드 검사 페이지에서 파일 및 폴더 선택과 뒤로가기 기능 구현

### DIFF
--- a/src/app/api/analyze/repository/route.ts
+++ b/src/app/api/analyze/repository/route.ts
@@ -1,0 +1,36 @@
+/**
+ * 주어진 요청에 따라 GitHub 리포지토리의 특정 경로에 있는 콘텐츠를 가져오는 함수.
+ *
+ * @async
+ * @function GET
+ * @param {Request} request - 들어오는 HTTP 요청 객체.
+ * @returns {Promise<Response>} - 리포지토리 콘텐츠의 JSON 데이터를 포함하는 Response 객체를 반환하는 Promise.
+ * @throws {Error} - GitHub API 요청에 실패한 경우 에러를 던짐.
+ *
+ * @example
+ * // 요청 URL 예시:
+ * // https://api.github.com/repos/{owner}/{repo}/contents/{path}
+ */
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const owner = searchParams.get("owner");
+    const repo = searchParams.get("repo");
+    const path = searchParams.get("path");
+    const url = `https://api.github.com/repos/${owner}/${repo}/contents/${path}`;
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `token ${process.env.NEXT_PUBLIC_PERSONAL_ACCESS_TOKENS}`,
+        Accept: "application/vnd.github+json",
+      },
+    });
+
+    const data = await res.json();
+    if (!res.ok) {
+      throw new Error("Failed to fetch repository contents");
+    }
+    return Response.json(data);
+  } catch (e) {
+    console.log(e);
+  }
+}

--- a/src/app/me/(analyze)/type.ts
+++ b/src/app/me/(analyze)/type.ts
@@ -1,18 +1,31 @@
-export type TFile = {
-  id: string;
-  fileName: string;
-  code: string;
+export type TGithubContentLinks = {
+  self: string;
+  git: string;
+  html: string;
 };
 
-export type TSelectedFiles = TFile & { isCodeAnalyzed?: string };
-// isCodeAnalyzed : completed(완료), pending(대기), error(오류)
-
-export type TSelectedFilesProps = {
-  selectedFiles: TSelectedFiles[];
-  onClick: (file: TSelectedFiles) => void;
+export type TGithubContent = {
+  name: string;
+  path: string;
+  sha: string;
+  size: number;
+  url: string;
+  html_url: string;
+  git_url: string;
+  download_url: string | null;
+  content?: string; // type이 file일 경우 content 프로퍼티 존재
+  encoding?: string; // type이 file일 경우 encoding 프로퍼티 존재
+  type: "file" | "dir";
+  _links: TGithubContentLinks;
 };
 
-export type TAnalysisResult = TFile & {
+export type TSelectedFiles = {
+  name: string;
+  sha: string;
+  content: string;
+};
+
+export type TAnalysisResult = TGithubContent & {
   results: {
     code: string;
     coment: string;

--- a/src/components/analyze/CodeArea.tsx
+++ b/src/components/analyze/CodeArea.tsx
@@ -3,6 +3,7 @@ import magnifier from "../../../public/images/magnifier.png";
 import folderDashed from "../../../public/images/folder-dashed.png";
 import bugImg from "../../../public/images/bug.svg";
 import reload from "../../../public/images/reload.png";
+import useSelectedFilesStore from "@/store/useSelectedFilesStore";
 
 const MESSAGES = {
   visible: "파일을 선택하세요",
@@ -25,30 +26,28 @@ const ANALYZE_TYPE = (
 
 /**
  * `TCodeAreaProps` 타입 정의
+ *
  * @typedef {Object} TCodeAreaProps
  * @property {string} type - 코드 영역의 상태를 나타냅니다.
  *   - `select`: 파일이 선택된 상태
  *   - `analyze`: 분석 대기 중인 상태
- * @property {string} fileCode - 출력할 파일 코드 부분입니다.
  */
-export type TCodeAreaProps = {
-  type: string;
-  fileCode: string;
-};
 
 /**
  * 코드 영역을 표시하는 컴포넌트입니다.
- * - `type`이 `"select"`일 경우: 파일 선택된 상태를 나타내는 추가 내용을 렌더링합니다.
- * - `type`이 `"analyze"`일 경우: 분석 대기 중 상태를 나타내는 추가 내용을 렌더링합니다.
  *
- * @param {TCodeAreaProps} props - 컴포넌트의 프로퍼티
+ * - `type`이 `"select"`일 경우: 파일이 선택된 상태를 나타내는 추가 내용을 렌더링합니다.
+ * - `type`이 `"analyze"`일 경우: 분석 대기 중인 상태를 나타내는 추가 내용을 렌더링합니다.
+ *
+ * @param {TCodeAreaProps} props - 컴포넌트의 속성.
  * @param {string} props.type - 코드 영역의 상태를 나타냅니다.
- * @param {string} props.fileCode - 출력할 파일 코드 부분입니다.
  *
- * @returns {JSX.Element} 코드 영역 컴포넌트
+ * @returns {JSX.Element} 코드 영역을 렌더링하는 JSX 요소를 반환합니다.
  */
 
-const CodeArea = ({ type, fileCode }: TCodeAreaProps) => {
+const CodeArea = ({ type }: { type: string }) => {
+  const selectedFiles = useSelectedFilesStore((state) => state.selectedFiles);
+  const fileCode = selectedFiles[selectedFiles.length - 1]?.content || "";
   const text = type === "select" ? MESSAGES.visible : MESSAGES.hidden;
   const codeAlt = type === "select" ? ALT_TEXT.visible : ALT_TEXT.hidden;
   const Icon = ICONS[type === "select" ? "visible" : "hidden"];
@@ -59,11 +58,13 @@ const CodeArea = ({ type, fileCode }: TCodeAreaProps) => {
 
   return (
     <div
-      className={`${!isSelected && "justify-center"} flex h-[976px] w-1/2 flex-col items-center gap-8 rounded-lg border-[1px] border-[#C3C3C3] px-10 py-11`}
+      className={`${!isSelected && "justify-center"} flex h-[976px] w-1/2 flex-col items-center gap-8 overflow-y-auto rounded-lg border-[1px] border-[#C3C3C3] py-11`}
     >
       {isSelected ? (
         // 파일 선택
-        <div className="relative flex flex-col items-center justify-center gap-10">
+        <div
+          className={`relative flex w-full flex-col items-center justify-center gap-10`}
+        >
           {type === "analyze" && ANALYZE_TYPE}
           <div
             className={`${isAnalyzed} flex flex-col items-center justify-center gap-6`}
@@ -73,7 +74,7 @@ const CodeArea = ({ type, fileCode }: TCodeAreaProps) => {
               취약성 검사 코드
             </div>
           </div>
-          <p className={isAnalyzed}>{code}</p>
+          <pre className={`${isAnalyzed} w-full px-6 text-sm`}>{code}</pre>
         </div>
       ) : (
         // 파일 미선택

--- a/src/components/analyze/FileList.tsx
+++ b/src/components/analyze/FileList.tsx
@@ -1,36 +1,85 @@
+"use client";
+
+import { useEffect } from "react";
+import leftArrowImg from "../../../public/images/left-arrow-pagination.png";
 import FileListItem from "./FileListItem";
-import { TFileListProps } from "./FileSideBar";
+import { TGithubContent } from "@/app/me/(analyze)/type";
+import useSelectedFilesStore from "@/store/useSelectedFilesStore";
+import useFilesStore from "@/store/useFilesStore";
+import Image from "next/image";
 
 /**
- * `FileList` 컴포넌트는 파일 목록을 렌더링합니다.
- * 각 파일 항목은 선택 상태에 따라 스타일이 적용되며,
- * 사용자가 항목을 클릭할 때 지정된 콜백 함수가 호출됩니다.
+ * `FileList` 컴포넌트는 파일 목록을 렌더링하는 역할을 합니다.
+ * 각 파일 항목은 선택된 상태에 따라 스타일이 다르게 적용되며,
+ * 사용자가 항목을 클릭할 때 해당 파일에 대한 처리를 위한 콜백 함수가 호출됩니다.
  *
- * @param {Object} props - 컴포넌트 속성
- * @param {Function} props.onClick - 파일 클릭 시 호출되는 콜백 함수
- * @param {TFile[]} props.fileData - 파일 데이터 배열
- * @param {TSelectedFiles[]} props.selectedFiles - 선택된 파일 목록
- * @returns {JSX.Element} - 파일 목록 구성 요소
+ * @returns {JSX.Element} - 파일 목록을 렌더링하는 JSX 요소를 반환합니다.
  */
-export default function FileList({
-  onClick,
-  fileData,
-  selectedFiles,
-}: TFileListProps) {
+
+export default function FileList() {
+  const selectedFiles = useSelectedFilesStore((state) => state.selectedFiles);
+  const files = useFilesStore((state) => state.files);
+  const fetchFiles = useFilesStore((state) => state.fecthFiles);
+  const folderPath = useSelectedFilesStore((state) => state.folderPath);
+  const moveFolderPath = useSelectedFilesStore((state) => state.moveFolderPath);
+
+  const isActiveMoveDir = folderPath !== "src";
+  const prevDirPath = folderPath.substring(0, folderPath.lastIndexOf("/"));
+  const moveDirName = folderPath.split("/")[folderPath.split("/").length - 1];
+
+  /**
+   * 특정 파일이 선택된 상태인지 확인하는 함수입니다.
+   *
+   * @param {TGithubContent} file - 선택 여부를 확인할 파일 객체
+   * @returns {boolean} - 파일이 선택된 경우 `true`, 그렇지 않은 경우 `false`를 반환합니다.
+   */
+  const isFileSelected = (file: TGithubContent) => {
+    const isSelected = selectedFiles.some(
+      (selectedFile) => selectedFile.sha === file.sha,
+    );
+    return isSelected;
+  };
+
+  /**
+   * 이전 폴더로 이동하는 함수입니다.
+   * 이전 폴더의 경로로 파일을 가져오고 상태를 업데이트합니다.
+   */
+  const handleClickPrevFolder = () => {
+    console.log();
+    if (prevDirPath) {
+      fetchFiles("flawdetector-team-yes", "flawdetector-team-yes", prevDirPath);
+      moveFolderPath(prevDirPath);
+    }
+  };
+
+  /**
+   * 컴포넌트가 마운트될 때 초기 폴더의 파일들을 가져오는 효과를 설정합니다.
+   */
+  useEffect(() => {
+    fetchFiles("flawdetector-team-yes", "flawdetector-team-yes", "src");
+  }, []);
+
   return (
     <>
       <ul className="h-[924px] overflow-y-auto">
-        {fileData.map((file) => {
-          const isSelected = selectedFiles.some(
-            (selectedFile) => selectedFile.id === file.id,
-          );
-          return (
-            <FileListItem
-              key={file.id}
-              isSelected={isSelected}
-              file={file}
-              onClick={onClick}
+        {isActiveMoveDir && (
+          <div
+            className="flex h-[44px] cursor-pointer items-center gap-2 border border-[#E6E6E6] p-2"
+            onClick={handleClickPrevFolder}
+          >
+            <Image
+              src={leftArrowImg}
+              alt="Prev Folder"
+              width={24}
+              height={24}
             />
+            <span className="text-base text-[#3F3F3F]">{moveDirName}</span>
+          </div>
+        )}
+        {files.map((file) => {
+          const isSelected = isFileSelected(file);
+          return (
+            <FileListItem key={file.sha} isSelected={isSelected} file={file} />
           );
         })}
       </ul>

--- a/src/components/analyze/FileListItem.tsx
+++ b/src/components/analyze/FileListItem.tsx
@@ -1,25 +1,77 @@
-import { TFile, TSelectedFiles } from "@/app/me/(analyze)/type";
+import { TGithubContent, TSelectedFiles } from "@/app/me/(analyze)/type";
 import fileImg from "../../../public/images/file.png";
+import folderImg from "../../../public/images/folder-open.png";
 import checkImg from "../../../public/images/check.png";
 import Image from "next/image";
+import useFilesStore, { fetchRepoContents } from "@/store/useFilesStore";
+import useSelectedFilesStore from "@/store/useSelectedFilesStore";
 
 type TFileListItemProps = {
-  file: TFile;
+  file: TGithubContent;
   isSelected: boolean;
-  onClick: (file: TSelectedFiles) => void;
 };
 
 /**
- * FileListItem 컴포넌트는 파일 항목을 렌더링하며, 선택 상태와 클릭 핸들러를 지원합니다.
- * @param {TFileListItemProps} props - 컴포넌트 속성
- * @param {TFile} props.file - 파일 정보 객체
+ * `FileListItem` 컴포넌트는 파일 항목을 렌더링하며, 선택 상태와 클릭 핸들러를 지원합니다.
+ *
+ * @param {TFileListItemProps} props - 컴포넌트의 속성
+ * @param {TGithubContent} props.file - 파일 정보 객체
  * @param {boolean} props.isSelected - 항목의 선택 상태
- * @param {(file: TSelectedFiles) => void} props.onClick - 클릭 이벤트 핸들러
+ * @returns {JSX.Element} - 파일 항목을 렌더링하는 JSX 요소
  */
-function FileListItem({ file, isSelected, onClick }: TFileListItemProps) {
+function FileListItem({ file, isSelected }: TFileListItemProps) {
+  const fetchFiles = useFilesStore((state) => state.fecthFiles);
+  const selectedFiles = useSelectedFilesStore((state) => state.selectedFiles);
+  const prevFolder = useSelectedFilesStore((state) => state.folderPath);
+  const selectFile = useSelectedFilesStore((state) => state.selectFile);
+  const removeFile = useSelectedFilesStore((state) => state.removeFile);
+
+  /**
+   * 파일 또는 폴더를 클릭했을 때 호출되는 핸들러입니다.
+   * 파일일 경우: 선택된 파일을 추가하거나 제거합니다.
+   * 폴더일 경우: 폴더를 선택하고 해당 폴더의 내용을 가져옵니다.
+   *
+   * @param {TGithubContent} file - 클릭된 파일 또는 폴더 객체
+   */
+  const handleClickBtn = async (file: TGithubContent) => {
+    // 파일일 경우
+    if (file.type === "file") {
+      const fileIndex = selectedFiles.findIndex((f) => f.sha === file.sha);
+
+      // 처음 선택한 파일일 경우
+      if (fileIndex === -1) {
+        try {
+          const fileData = await fetchRepoContents(
+            "flawdetector-team-yes",
+            "flawdetector-team-yes",
+            `${prevFolder}/${file.name}`,
+          );
+          if (fileData && fileData.content) {
+            const decodedContent = atob(fileData.content);
+            selectFile("file", fileData.name, fileData.sha, decodedContent);
+          }
+        } catch (error) {
+          console.error("Error fetching or decoding file:", error);
+        }
+      } else {
+        // 이미 선택한 파일일 경우
+        removeFile(file.sha);
+      }
+      // 폴더일 경우
+    } else {
+      selectFile("dir", file.name);
+      fetchFiles(
+        "flawdetector-team-yes",
+        "flawdetector-team-yes",
+        `${prevFolder}/${file.name}`,
+      );
+    }
+  };
+
+  const isFile = file.type === "file";
   return (
     <li
-      onClick={() => onClick(file)}
+      onClick={() => handleClickBtn(file)}
       className={`flex h-[44px] cursor-pointer items-center gap-2 border border-[#E6E6E6] p-2 ${
         isSelected ? "bg-[#E3E1E7]" : "hover:bg-[#E3E1E7]"
       }`}
@@ -27,8 +79,13 @@ function FileListItem({ file, isSelected, onClick }: TFileListItemProps) {
       {isSelected && (
         <Image src={checkImg} alt="Selected" width={24} height={24} />
       )}
-      <Image src={fileImg} alt="File" width={24} height={24} />
-      <span className="text-base text-[#3F3F3F]">{file.fileName}</span>
+      <Image
+        src={isFile ? fileImg : folderImg}
+        alt={`${isFile ? "File" : "Folder"}`}
+        width={24}
+        height={24}
+      />
+      <span className="text-base text-[#3F3F3F]">{file.name}</span>
     </li>
   );
 }

--- a/src/components/analyze/FileSideBar.tsx
+++ b/src/components/analyze/FileSideBar.tsx
@@ -3,31 +3,19 @@ import xMarkError from "../../../public/images/x-mark-error.png";
 import triangleYellow from "../../../public/images/triangle-yellow.png";
 import circleGreen from "../../../public/images/circle-green.png";
 import menuRepoFolder from "../../../public/images/menu-repo-folder.png";
-import { TFile, TSelectedFiles } from "@/app/me/(analyze)/type";
 import StateItem from "./StateItem";
 import FileList from "./FileList";
-
-export type TFileListProps = {
-  onClick: (file: TSelectedFiles) => void;
-  fileData: TFile[];
-  selectedFiles: TSelectedFiles[];
-};
 
 /**
  * `FileSideBar` 컴포넌트는 사이드바를 렌더링하며, 통계와 프로필, 파일 목록을 포함합니다.
  * 통계는 상태 항목을 표시하고, 프로필 영역과 파일 목록이 하위 요소로 포함됩니다.
  *
- * @param {Object} props - 컴포넌트 속성
+ * @param {Object} props - 컴포넌트의 속성
  * @param {Function} props.onClick - 파일 클릭 시 호출되는 콜백 함수
- * @param {TFile[]} props.fileData - 파일 데이터 배열
  * @param {TSelectedFiles[]} props.selectedFiles - 선택된 파일 목록
- * @returns {JSX.Element} - 사이드바 구성 요소
+ * @returns {JSX.Element} - 사이드바 컴포넌트
  */
-export default function FileSideBar({
-  onClick,
-  fileData,
-  selectedFiles,
-}: TFileListProps) {
+export default function FileSideBar() {
   return (
     <>
       <aside className="flex h-[1163px] w-[247px] flex-col justify-between">
@@ -38,8 +26,8 @@ export default function FileSideBar({
           <StateItem src={circleGreen} alt="Success" count={23} />
         </div>
 
-        {/* 프로필 */}
         <div className="h-[994px] w-[247px] scroll-smooth rounded-xl border-[1px] border-[#C3C3C3]">
+          {/* 프로필 */}
           <div className="flex h-[70px] justify-between rounded-t-xl bg-primary-50 p-5">
             <div className="flex items-center gap-[10px] text-xl">
               <img
@@ -61,11 +49,7 @@ export default function FileSideBar({
             </div>
           </div>
           {/* 파일 목록 */}
-          <FileList
-            fileData={fileData}
-            onClick={onClick}
-            selectedFiles={selectedFiles}
-          />
+          <FileList />
         </div>
         <button
           className="fill-radius-8px-lg w-[246px] text-xl"

--- a/src/components/analyze/ProgressList.tsx
+++ b/src/components/analyze/ProgressList.tsx
@@ -1,29 +1,18 @@
-import { TSelectedFilesProps } from "@/app/me/(analyze)/type";
 import InputChips from "./InputChips";
 import ProgressBar from "./ProgressBar";
+import useSelectedFilesStore from "@/store/useSelectedFilesStore";
 
 /**
- * `ProgressList` 컴포넌트는 파일 목록과 진행 상황을 시각적으로 표시합니다.
+ * `ProgressList` 컴포넌트는 선택된 파일 목록과 파일 분석 진행 상황을 시각적으로 표시합니다.
  *
- * - `selectedFiles`: 현재 선택된 파일들의 배열입니다.
- * - `onClick`: 파일을 클릭할 때 호출되는 핸들러 함수입니다.
+ * - 선택된 파일들을 `InputChips` 컴포넌트를 사용하여 목록으로 표시합니다.
+ * - `ProgressBar` 컴포넌트를 사용하여 파일 분석 진행 상태를 표시합니다.
  *
- * 컴포넌트는 선택된 파일들을 표시하고, 진행 바를 통해 파일 분석 진행 상태를 나타냅니다.
- *
- * @param {TSelectedFilesProps} props - 컴포넌트에 전달되는 속성들.
- * @param {TSelectedFiles[]} props.selectedFiles - 선택된 파일의 배열.
- * @param {(file: TSelectedFiles) => void} props.onClick - 파일 클릭 시 호출되는 핸들러 함수.
- * @returns {JSX.Element} - 렌더링된 컴포넌트.
+ * @returns {JSX.Element} - 렌더링된 `ProgressList` 컴포넌트
  */
-export default function ProgressList({
-  selectedFiles,
-  onClick,
-}: TSelectedFilesProps): JSX.Element {
-  // 진행률 계산
-  const progress =
-    (selectedFiles.filter((file) => file.isCodeAnalyzed !== "Success").length /
-      selectedFiles.length) *
-    100;
+export default function ProgressList(): JSX.Element {
+  const selectedFiles = useSelectedFilesStore((state) => state.selectedFiles);
+  const removeFile = useSelectedFilesStore((state) => state.removeFile);
 
   // 테스트용 진행도
   const testProgress = 45;
@@ -36,8 +25,8 @@ export default function ProgressList({
           style={{ overflowX: "hidden" }}
         >
           {selectedFiles.map((file) => (
-            <InputChips onClick={() => onClick(file)} key={file.id}>
-              {file.fileName}
+            <InputChips onClick={() => removeFile(file.sha)} key={file.sha}>
+              {file.name}
             </InputChips>
           ))}
         </div>

--- a/src/components/analyze/ai-analyze/FileAnalysisItem.tsx
+++ b/src/components/analyze/ai-analyze/FileAnalysisItem.tsx
@@ -9,17 +9,14 @@ import folderOpenImg from "../../../../public/images/folder-open.png";
  *
  * @param {Object} props - 컴포넌트 속성
  * @param {string} props.fileName - 파일 이름
- * @param {string} props.code - 파일 코드
  * @param {Object[]} props.results - 분석 결과 배열
  * @returns {JSX.Element} - 파일 분석 항목 구성 요소
  */
 export default function FileAnalysisItem({
   fileName,
-  code,
   results,
 }: {
   fileName: string;
-  code: string;
   results: { code: string; coment: string }[];
 }): JSX.Element {
   return (
@@ -29,7 +26,7 @@ export default function FileAnalysisItem({
         <span>{`sfacweb-1/${fileName}`}</span>
       </div>
       <div className="flex w-full gap-7">
-        <CodeArea type="select" fileCode={code} />
+        <CodeArea type="select" />
         <Infobox results={results} />
       </div>
     </li>

--- a/src/components/analyze/ai-analyze/FileAnalysisList.tsx
+++ b/src/components/analyze/ai-analyze/FileAnalysisList.tsx
@@ -21,9 +21,8 @@ export default function FileAnalysisList({
         <ul className="flex flex-col gap-8">
           {analysisResults.map((result: TAnalysisResult) => (
             <FileAnalysisItem
-              key={result.id}
-              fileName={result.fileName}
-              code={result.code}
+              key={result.sha}
+              fileName={result.name}
               results={result.results}
             />
           ))}

--- a/src/components/analyze/ai-analyze/FileAnalysisSideBar.tsx
+++ b/src/components/analyze/ai-analyze/FileAnalysisSideBar.tsx
@@ -21,11 +21,11 @@ export default function FileAnalysisSideBar({
         <ul className="w-[247px] rounded-sm">
           {analysisResults.map((result: TAnalysisResult) => (
             <li
-              key={result.id}
+              key={result.sha}
               className="flex h-[44px] gap-1 border-[1px] border-t-0 border-[#C3C3C3] p-2 first:rounded-t-md first:border-t last:rounded-b-md"
             >
               <Image src={fileImg} alt="File" width={24} height={24} />
-              <span>{result.fileName}</span>
+              <span>{result.name}</span>
             </li>
           ))}
         </ul>

--- a/src/lib/decodeUnicode.ts
+++ b/src/lib/decodeUnicode.ts
@@ -1,0 +1,22 @@
+/**
+ * 주어진 Base64 인코딩된 문자열을 유니코드 문자열로 디코딩합니다.
+ *
+ * 이 함수는 문자열을 다음과 같은 단계로 변환합니다:
+ * 1. Base64로 인코딩된 문자열을 디코딩하여 바이너리 데이터를 얻습니다.
+ * 2. 바이너리 데이터를 퍼센트 인코딩 형식으로 변환합니다.
+ * 3. 퍼센트 인코딩된 문자열을 다시 원래의 유니코드 문자열로 변환합니다.
+ *
+ * @param {string} str - Base64로 인코딩된 문자열. 이 문자열은 유니코드 문자열을 Base64로 인코딩한 것입니다.
+ * @returns {string} - 디코딩된 유니코드 문자열.
+ */
+export function decodeUnicode(str: string) {
+  // Going backwards: from bytestream, to percent-encoding, to original string.
+  return decodeURIComponent(
+    atob(str)
+      .split("")
+      .map(function (c) {
+        return "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2);
+      })
+      .join(""),
+  );
+}

--- a/src/lib/sortDirOverFiles.ts
+++ b/src/lib/sortDirOverFiles.ts
@@ -1,0 +1,23 @@
+import { TGithubContent } from "@/app/me/(analyze)/type";
+
+/**
+ * 주어진 항목 배열을 정렬하여 디렉토리(`dir`) 항목이 파일(`file`) 항목보다 먼저 오도록 합니다.
+ *
+ * @param {TGithubContent[]} items - 정렬할 항목들의 배열입니다. 각 항목은 `TGithubContent` 타입이어야 합니다.
+ * @returns {TGithubContent[]} - 디렉토리 항목이 파일 항목보다 먼저 오는 정렬된 배열을 반환합니다.
+ *
+ * 정렬 기준:
+ * - `type`이 `"dir"`인 항목이 `type`이 `"file"`인 항목보다 먼저 오도록 합니다.
+ * - 두 항목의 `type`이 동일할 경우, 순서를 변경하지 않습니다.
+ */
+export const sortDirOverFiles = (items: TGithubContent[]) => {
+  return items.sort((a, b) => {
+    if (a.type === "dir" && b.type === "file") {
+      return -1; // a가 b보다 먼저 오게
+    }
+    if (a.type === "file" && b.type === "dir") {
+      return 1; // b가 a보다 먼저 오게
+    }
+    return 0; // 같은 타입이면 순서를 변경하지 않음
+  });
+};

--- a/src/store/useFilesStore.tsx
+++ b/src/store/useFilesStore.tsx
@@ -1,0 +1,58 @@
+import { TGithubContent } from "@/app/me/(analyze)/type";
+import { sortDirOverFiles } from "@/lib/sortDirOverFiles";
+import { create } from "zustand";
+
+/**
+ * GitHub 저장소의 특정 경로에서 파일 콘텐츠를 가져오는 함수입니다.
+ *
+ * 이 함수는 주어진 저장소와 경로에 대한 API 요청을 수행하여 파일 내용을 가져옵니다.
+ *
+ * @param {string} owner - GitHub 저장소 소유자의 사용자 이름.
+ * @param {string} repo - GitHub 저장소의 이름.
+ * @param {string} path - 가져올 파일의 경로.
+ * @returns {Promise<TGithubContent[]>} - API 요청의 결과로 얻어진 파일 내용의 배열입니다. 요청이 실패하면 빈 배열을 반환합니다.
+ */
+export const fetchRepoContents = async (
+  owner: string,
+  repo: string,
+  path: string,
+) => {
+  try {
+    const response = await fetch(
+      `/api/analyze/repository?owner=${owner}&repo=${repo}&path=${path}`,
+    );
+    if (!response.ok) {
+      throw new Error("Failed to fetch repository contents");
+    }
+    const result = await response.json();
+    return result;
+  } catch (err) {
+    console.error("Error fetching repository contents:", err);
+    return [];
+  }
+};
+
+type TFileState = {
+  files: TGithubContent[];
+  fecthFiles: (owner: string, repo: string, path: string) => Promise<void>;
+};
+
+/**
+ * GitHub 저장소 파일 상태를 관리하는 Zustand 상태 관리 훅입니다.
+ *
+ * 이 훅은 저장소의 파일 목록을 상태로 관리하며, 파일을 가져오는 기능을 제공합니다.
+ *
+ * @returns {TFileState} - 상태와 상태를 업데이트하는 함수들로 구성된 객체입니다.
+ * @property {TGithubContent[]} files - 현재 상태에서 관리하는 파일 내용의 배열입니다.
+ * @property {(owner: string, repo: string, path: string) => Promise<void>} fecthFiles - 주어진 저장소와 경로에 대해 파일을 가져오는 비동기 함수입니다.
+ */
+const useFilesStore = create<TFileState>((set) => ({
+  files: [],
+  fecthFiles: async (owner: string, repo: string, path: string) => {
+    const data = await fetchRepoContents(owner, repo, path);
+    const sortedData = sortDirOverFiles(data);
+    set({ files: sortedData });
+  },
+}));
+
+export default useFilesStore;

--- a/src/store/useSelectedFilesStore.tsx
+++ b/src/store/useSelectedFilesStore.tsx
@@ -1,0 +1,69 @@
+import { TSelectedFiles } from "@/app/me/(analyze)/type";
+import { create } from "zustand";
+
+type TSelectedFilesState = {
+  selectedFiles: TSelectedFiles[];
+  folderPath: string;
+  moveFolderPath: (path: string) => void;
+  selectedAllFile: (selectedAllFiles: TSelectedFiles[]) => void;
+  selectFile: (
+    type: string,
+    name: string,
+    sha?: string,
+    content?: string,
+  ) => void;
+  removeFile: (sha: string) => void;
+};
+
+/**
+ * 선택된 파일 및 폴더 경로를 관리하는 Zustand 상태 훅입니다.
+ *
+ * 이 훅은 사용자가 선택한 파일과 폴더 경로를 상태로 관리하며, 파일 선택 및 제거, 폴더 경로 이동 기능을 제공합니다.
+ *
+ * @returns {TSelectedFilesState} - 상태와 상태를 업데이트하는 함수들로 구성된 객체입니다.
+ * @property {TSelectedFiles[]} selectedFiles - 현재 선택된 파일들의 배열입니다.
+ * @property {string} folderPath - 현재 선택된 폴더의 경로입니다.
+ * @property {(path: string) => void} moveFolderPath - 폴더 경로를 업데이트하는 함수입니다.
+ * @property {(selectedAllFiles: TSelectedFiles[]) => void} selectedAllFile - 모든 파일을 선택하는 함수입니다.
+ * @property {(type: string, name: string, sha?: string, content?: string) => void} selectFile - 파일 또는 폴더를 선택하는 함수입니다.
+ * @property {(sha: string) => void} removeFile - 선택된 파일을 제거하는 함수입니다.
+ */
+
+const useSelectedFilesStore = create<TSelectedFilesState>((set, get) => ({
+  selectedFiles: [],
+  folderPath: "src",
+  moveFolderPath: (path: string) => set({ folderPath: path }),
+  selectedAllFile: (selectedAllFiles: TSelectedFiles[]) =>
+    set({ selectedFiles: selectedAllFiles }),
+  selectFile: (
+    type: string,
+    name: string,
+    sha: string = "",
+    content: string = "",
+  ) => {
+    const { folderPath } = get();
+    // 파일일 경우
+    if (type === "file") {
+      set((state) => ({
+        selectedFiles: [
+          ...state.selectedFiles,
+          {
+            name,
+            sha,
+            content,
+          },
+        ],
+      }));
+    } else {
+      // 폴더일 경우
+      set({ folderPath: `${folderPath}/${name}` });
+    }
+  },
+  removeFile: (sha: string) => {
+    set((state) => ({
+      selectedFiles: state.selectedFiles.filter((f) => f.sha !== sha),
+    }));
+  },
+}));
+
+export default useSelectedFilesStore;


### PR DESCRIPTION
## 🚨 관련 이슈
#41   
## 🚀 작업 내용

## TODO
- [x] GitHub API 요청을 위한 API 라우트 생성
   - src/app/api/analyze/repository/route.ts
- [x] 페이지 진입 시 src 폴더 데이터 로드 및 바인딩
- [x] FileListItem 컴포넌트 리팩토링
   - 파일과 폴더를 type props로 구분하여 처리
   - 관련 이미지 예시 
      -  ![image](https://github.com/user-attachments/assets/1a950265-1b0f-4e3e-aaf1-9608c7ce0341)
      -  ![image](https://github.com/user-attachments/assets/23238b42-adbf-4a01-b544-6407132e0d34)
- [x] 폴더 선택 기능 구현
   - 폴더 클릭 시 해당 폴더 경로로 GitHub API 요청을 보내고 결과 바인딩
   - FileList 상단에 뒤로 가기 버튼 추가
   - folder 항목이 file 항목보다 먼저 나오도록 데이터 정렬
- [x] 파일 선택 기능 구현
  - 파일 클릭 시 해당 파일 경로로 GitHub API 요청 후 데이터를 바인딩
  - 파일의 내용을 base64로 디코딩하여 {name, sha, content} 형태로 useSelectedFiles의 selectedFiles에 저장
- [x] 뒤로 가기 기능 구현
  - 뒤로 가기 버튼 클릭 시 이전 폴더 경로로 GitHub API 요청을 보내고 결과 바인딩
- [x] 파일 전체 선택 기능 구현
  - `폴더 전체 검사` 에서 `파일 전체 선택` 으로 변경 
  - 파일 GIthub API를 Promise.all로 병렬로 요청하여 동일한 시간에 파일들이 파일 선택 ui로 변경할 수 있게 처리


## 📝 참고 사항(선택)

- 파일 및 폴더 선택 api 요청 롲기
   -  ![image](https://github.com/user-attachments/assets/dc878524-d07a-4a84-b926-856e35a30dc9)


## 🖼️ 스크린샷(선택)

![FlawDetector-Chrome2024-08-2615-15-33-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/76a97925-2ad2-4bd6-8153-afbe1acaa24a)




## ✅ 이후 계획(선택)

- Github API 요청 로딩 처리
- content Base64 디코딩 오류 문제
- web worker 사용해서 llama3 코드 검사 비동기 요청
- web worker 에 progress 값 가져와서 진행도 ui에 반영 

