### PR TITLE
feat: 데이터 크롤링 및 db저장

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "firebase": "^10.13.0",
     "next": "14.2.5",
     "next-auth": "^5.0.0-beta.20",
+    "puppeteer": "^23.3.0",
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.52.2",

--- a/src/scripts/addDataToFirebase.js
+++ b/src/scripts/addDataToFirebase.js
@@ -1,0 +1,37 @@
+import db from "@/firebase/firebaseClient";
+import { collection, addDoc, query, where, getDocs } from "firebase/firestore";
+
+/**
+ * Firestore의 "vulnerability" 컬렉션에 데이터를 추가하는 비동기 함수입니다.
+ * 만약 주어진 subtitle이 이미 존재하면 데이터를 추가하지 않습니다.
+ * @param {string} title - 추가할 데이터의 제목입니다.
+ * @param {string} subtitle - 추가할 데이터의 부제목입니다.
+ * @param {string} content - 추가할 데이터의 내용입니다.
+ * @param {string[]} arrayTable - 추가할 데이터의 배열 테이블입니다.
+ * @returns {Promise<void>} - 데이터 추가가 완료된 후에는 아무것도 반환하지 않습니다.
+ */
+export default async function addDataToFirebase(
+  title,
+  subtitle,
+  content,
+  arrayTable,
+) {
+  try {
+    const vulnerabilityRef = collection(db, "vulnerability"); // Firestore의 컬렉션 참조 생성
+
+    // Firestore에서 동일한 subtitle을 가진 문서를 조회하는 쿼리 생성
+    const q = query(vulnerabilityRef, where("subtitle", "==", subtitle));
+    const snapshot = await getDocs(q);
+
+    if (snapshot.empty) {
+      // 동일한 subtitle이 없다면 새로운 데이터를 Firestore에 추가
+      await addDoc(vulnerabilityRef, { title, subtitle, content, arrayTable });
+      console.log("새로운 subtitle이 Firestore에 추가되었습니다.");
+    } else {
+      console.log("같은 subtitle이 이미 Firestore에 존재합니다.");
+    }
+  } catch (error) {
+    // 데이터 처리 중 오류가 발생한 경우 콘솔에 에러 출력
+    console.error("데이터 처리 중 오류 발생:", error);
+  }
+}

--- a/src/scripts/crawling.js
+++ b/src/scripts/crawling.js
@@ -1,0 +1,221 @@
+import puppeteer from "puppeteer";
+import handler from "./trans";
+import parseTextToArray from "./parseTextToArray";
+import fetchToken from "./fetch-token";
+import addDataToFirebase from "./addDataToFirebase";
+
+/**
+ * 웹 스크래핑을 수행하여 데이터를 추출하는 함수입니다.
+ * @async
+ * @function crawling
+ */
+export default async function crawling() {
+  const PAGE_COUNT = 1; // 스크랩할 페이지네이션 페이지 수
+  const BASE_URL = "https://www.cnnvd.org.cn/home/warn";
+  const TIMEOUT = 600000; // 페이지 로딩 타임아웃 설정
+
+  try {
+    const browser = await puppeteer.launch({ headless: false });
+    const page = await browser.newPage();
+    const token = await fetchToken();
+    await page.goto(BASE_URL, { waitUntil: "networkidle0", timeout: TIMEOUT });
+
+    // 전체 페이지네이션 개수 카운트 시 사용
+    // const liElements = await getPageNumbers(page);
+
+    for (let i = 0; i < PAGE_COUNT; i++) {
+      const objs = await getPageData(page);
+
+      for (let j = 0; j < Math.min(10, objs.length); j++) {
+        // for (let j = 0; j < 2; j++) {
+        await navigateToPage(page, i + 1);
+
+        if (await isElementPresent(page, j)) {
+          await clickElement(page, j);
+          const pageData = await extractPageData(page);
+          await translateAndLogData(pageData, token);
+          await page.goto(BASE_URL, { waitUntil: "networkidle0" });
+        } else {
+          console.log(`Element ${j + 1}을(를) 찾을 수 없습니다.`);
+        }
+      }
+    }
+
+    await browser.close();
+  } catch (error) {
+    console.error("데이터를 가져오는 중 오류 발생:", error);
+  }
+}
+
+/**
+ * 페이지네이션에서 사용 가능한 총 페이지 수를 가져옵니다.
+ * @async
+ * @function getPageNumbers
+ * @param {puppeteer.Page} page - Puppeteer 페이지 객체
+ * @returns {Promise<Array<Object>>} - 페이지 정보가 포함된 객체 배열
+ */
+async function getPageNumbers(page) {
+  return await page.$$eval(".el-pager li", (elements) =>
+    elements.map((item) => ({
+      li: item.textContent,
+    })),
+  );
+}
+
+/**
+ * 현재 페이지에서 데이터를 가져옵니다.
+ * @async
+ * @function getPageData
+ * @param {puppeteer.Page} page - Puppeteer 페이지 객체
+ * @returns {Promise<Array<Object>>} - 제목과 날짜가 포함된 데이터 객체 배열
+ */
+async function getPageData(page) {
+  return await page.$$eval(".content-center", (elements) =>
+    elements.map((e) => ({
+      title: e.querySelector(".content-title")?.textContent,
+      date: e.querySelector(".content-detail")?.textContent,
+    })),
+  );
+}
+
+/**
+ * 특정 페이지로 네비게이션합니다.
+ * @async
+ * @function navigateToPage
+ * @param {puppeteer.Page} page - Puppeteer 페이지 객체
+ * @param {number} pageIndex - 네비게이션할 페이지 인덱스
+ */
+async function navigateToPage(page, pageIndex) {
+  await Promise.all([
+    page.click(`.el-pager li:nth-child(${pageIndex})`),
+    page.waitForSelector(".content-title", { timeout: 60000 }),
+  ]);
+}
+
+/**
+ * 페이지에서 특정 요소가 존재하는지 확인합니다.
+ * @async
+ * @function isElementPresent
+ * @param {puppeteer.Page} page - Puppeteer 페이지 객체
+ * @param {number} index - 확인할 요소의 인덱스
+ * @returns {Promise<boolean>} - 요소가 존재하면 true, 아니면 false
+ */
+async function isElementPresent(page, index) {
+  const elements = await page.$$(".el-col-16 > *");
+  return elements[index] !== undefined;
+}
+
+/**
+ * 페이지에서 특정 요소를 클릭합니다.
+ * @async
+ * @function clickElement
+ * @param {puppeteer.Page} page - Puppeteer 페이지 객체
+ * @param {number} index - 클릭할 요소의 인덱스
+ */
+async function clickElement(page, index) {
+  await page.evaluate((i) => {
+    const element = document.querySelectorAll(".el-col-16 > *")[i];
+    element.click();
+  }, index);
+
+  console.log(`Element ${index + 1}이(가) 성공적으로 클릭되었습니다.`);
+}
+
+/**
+ * 클릭한 요소에서 상세 데이터를 추출합니다.
+ * @async
+ * @function extractPageData
+ * @param {puppeteer.Page} page - Puppeteer 페이지 객체
+ * @returns {Promise<Object>} - 상세 제목, 부제목, 내용, 테이블 데이터가 포함된 객체
+ */
+async function extractPageData(page) {
+  await page.waitForSelector(".detail-info");
+
+  return await page.evaluate(() => {
+    const detailTitle =
+      document.querySelector(".detail-title")?.textContent || "";
+    const detailSubtitle =
+      document.querySelector(".detail-subtitle")?.textContent || "";
+
+    const sections = [];
+    let currentSection = [];
+    const detailContent = document.querySelector(".detail-content");
+
+    if (detailContent !== null) {
+      const firstChildTags = detailContent.children;
+
+      for (let tag of firstChildTags) {
+        const tagName = tag.tagName.toLowerCase();
+        const tagText = tag.textContent.trim();
+
+        if (
+          tagName === "table" ||
+          (tagName === "p" && tag.innerHTML.trim() === "&nbsp;")
+        ) {
+          break;
+        }
+
+        if (tagName === "p" && tag.querySelector("strong") !== null) {
+          if (currentSection.length > 0) {
+            sections.push(`<div>${currentSection.join(" ")}</div>`);
+            currentSection = [];
+          }
+          sections.push(
+            `<div className="font-extrabold mt-3 mb-1">${tagText}</div>`,
+          );
+        } else {
+          currentSection.push(tagText);
+        }
+      }
+
+      if (currentSection.length > 0) {
+        sections.push(`<div>${currentSection.join(" ")}</div>`);
+      }
+    }
+
+    const contents = sections.join("");
+
+    const rows = Array.from(document.querySelectorAll("table tbody tr"));
+    const table = rows
+      .slice(0, 11)
+      .map((row) => {
+        const cells = Array.from(row.querySelectorAll("td")).map((cell) =>
+          cell?.textContent.trim(),
+        );
+        return cells.join(" + ");
+      })
+      .join(" + ");
+
+    return { detailTitle, detailSubtitle, contents, table };
+  });
+}
+
+/**
+ * 추출한 페이지 데이터를 번역합니다.
+ * @async
+ * @function translateAndLogData
+ * @param {Object} pageData - 추출한 페이지 데이터
+ * @param {string} pageData.detailTitle - 상세 제목
+ * @param {string} pageData.detailSubtitle - 부제목
+ * @param {string} pageData.contents - 내용
+ * @param {string} pageData.table - 테이블 데이터
+ */
+async function translateAndLogData(pageData, token) {
+  const transData = await Promise.all([
+    handler(pageData.detailTitle, token),
+    handler(pageData.detailSubtitle, token),
+    handler(pageData.contents, token),
+    handler(pageData.table, token),
+  ]);
+  const [title, subtitle, content, table] = transData;
+  const arrayTable = parseTextToArray(table);
+
+  console.log("번역된 데이터:");
+  console.log(`제목: ${transData[0]}`);
+  console.log(`부제목: ${transData[1]}`);
+  console.log(`내용: ${transData[2]}`);
+  console.log(`테이블: ${arrayTable}`);
+
+  // 파이어베이스에 데이터 넣기
+  // await addDataToFirebase(title, subtitle, content, arrayTable);
+}

--- a/src/scripts/fetch-token.js
+++ b/src/scripts/fetch-token.js
@@ -1,0 +1,35 @@
+/**
+ * 서버에서 인증 토큰을 가져오는 비동기 함수입니다.
+ * @returns {Promise<string | undefined>} - 성공 시 서버에서 받은 액세스 토큰 문자열을 반환합니다. 실패 시 undefined를 반환합니다.
+ */
+export default async function fetchToken() {
+  const url = "http://43.203.238.76:8000/auth/token";
+
+  // 요청에 사용할 데이터 생성
+  const data = new URLSearchParams({
+    username: process.env.NEXT_PUBLIC_USERNAME,
+    password: process.env.NEXT_PUBLIC_PASSWORD,
+  });
+
+  try {
+    // 인증 요청 보내기
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: data.toString(),
+    });
+
+    // 응답을 JSON으로 파싱
+    const responseData = await response.json();
+
+    // access_token 추출
+    const accessToken = responseData.access_token;
+    console.log(accessToken);
+
+    return accessToken;
+  } catch (error) {
+    console.error("Error:llama3 fetch 에러:", error);
+  }
+}

--- a/src/scripts/parseTextToArray.ts
+++ b/src/scripts/parseTextToArray.ts
@@ -1,0 +1,14 @@
+/**
+ * 주어진 문자열을 `" + "` 구분자를 사용하여 배열로 변환하는 함수입니다.
+ * @param {string} input - 변환할 문자열입니다. 문자열이 비어있거나 null일 경우 null을 반환합니다.
+ * @returns {string[] | null} - 문자열을 배열로 변환한 결과 배열 또는 입력이 없을 경우 null입니다.
+ */
+export default function parseTextToArray(input: string): string[] | null {
+  if (!input) {
+    return null;
+  }
+
+  const result = input.split(" + ");
+
+  return result;
+}

--- a/src/scripts/trans.js
+++ b/src/scripts/trans.js
@@ -1,0 +1,40 @@
+/**
+ * 서버에 메시지를 전송하고 응답을 받아오는 비동기 핸들러 함수입니다.
+ * @param {string} message - 서버에 전송할 사용자 메시지. 메시지가 없으면 null을 반환합니다.
+ * @param {string} token - API 요청에 필요한 인증 토큰입니다.
+ * @returns {Promise<string|null>} - 서버로부터 받은 응답 텍스트 또는 에러 발생 시 null입니다.
+ */
+export default async function handler(message, token) {
+  const url = "http://43.203.238.76:8000/generate";
+
+  const data = {
+    user_message: `${message} 한글로 번역, 글자 생략 금지`,
+    temperature: 0.9,
+    top_p: 0.9,
+  };
+
+  if (!message) {
+    return null;
+  }
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const result = await response.text();
+    return result;
+  } catch (error) {
+    console.error("Error:", error);
+    return null;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,12 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "**/*.js"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 🚨 관련 이슈
#55 
#61 

## 🚀 작업 내용
- 데이터 크롤링: puppeteer 라이브러리 사용
- 번역: llama3 로그인 후 토큰값 저장 후 질의 답변저장으로 번역
- DB: firebase 데이터 검증 후 없는 내용만 저장

## 📝 참고 사항(선택)
- 자동화 테스트를 위해 페이지네이션 1개에서 2개의 데이터만 가져오도록 설정했습니다.

## 🖼️ 스크린샷(선택)
![image](https://github.com/user-attachments/assets/10c2cd12-8005-4992-aeea-ba41cf6f61c2)
![image](https://github.com/user-attachments/assets/99972d5f-15c2-47ad-bc44-fc7fc5b051b6)


## ✅ 이후 계획(선택)
- github action으로 자동화
- vulnerability-db 페이지 완성
- 디자인 변경사항 수정
