### PR TITLE
chore: 배포 오류로 critters 패키지 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/nodemailer": "^6.4.16",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "critters": "^0.0.25",
     "eslint": "^8",
     "eslint-config-next": "14.2.5",
     "postcss": "^8",


### PR DESCRIPTION
## 🚨 관련 이슈

#163

## 🚀 작업 내용

- critters 설치
  - (🔺) Vercel 배포 오류나서 critters 패키지 --save-dev 옵션으로 설치함.

## ✅ 이후 계획

- 재배포 후 적용되는 상황을 보고 수정예정
