### PR TITLE
fix: CodeMirror theme 적용 import 코드 수정

### DIFF
--- a/src/components/analyze/CodeViewer.tsx
+++ b/src/components/analyze/CodeViewer.tsx
@@ -2,7 +2,7 @@
 
 import CodeMirror from "@uiw/react-codemirror";
 import { javascript } from "@codemirror/lang-javascript";
-import { eclipse } from "@uiw/codemirror-theme-eclipse";
+import { eclipse } from "@uiw/codemirror-theme-eclipse/esm/index";
 import magnifier from "../../../public/images/magnifier.png";
 import {
   EditorView,


### PR DESCRIPTION
## 🚨 관련 이슈

#163

## 🚀 작업 내용

- [x] CodeMirror theme 적용 CodeViewer import 문 수정
  ```js
    import { eclipse } from "@uiw/codemirror-theme-eclipse/esm/index";

    // 기존 import 문은 아래와 같습니다.
    // import { eclipse } from "@uiw/codemirror-theme-eclipse";
  ```

## ✅ 이후 계획

- 정적 파일 경로 재확인
