### PR TITLE
fix:  global.css 수정, createTheme을 사용한 eclipse 테마 적용

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,8 @@
 @tailwind utilities;
 
 @import "../components/common/button/button.css";
+
+
 :root {
   --font-family: var(--font-pretendard);
 }
@@ -36,9 +38,5 @@ body {
 @layer components {
   .item-middle {
     @apply flex items-center justify-center;
-  }
-
-  .cm-content {
-    all: unset;
   }
 }

--- a/src/components/analyze/CodeViewer.tsx
+++ b/src/components/analyze/CodeViewer.tsx
@@ -2,7 +2,8 @@
 
 import CodeMirror from "@uiw/react-codemirror";
 import { javascript } from "@codemirror/lang-javascript";
-import { eclipse } from "@uiw/codemirror-theme-eclipse";
+// import { eclipse } from "@uiw/codemirror-theme-eclipse";
+import { createTheme } from "@uiw/codemirror-themes";
 import magnifier from "../../../public/images/magnifier.png";
 import {
   EditorView,
@@ -12,8 +13,36 @@ import {
   DecorationSet,
 } from "@codemirror/view";
 import { RangeSetBuilder, Extension } from "@codemirror/state";
+import { tags as t } from "@lezer/highlight";
 import useSelectedFilesStore from "@/store/useSelectedFilesStore";
 import Image from "next/image";
+
+const eclipseTheme = createTheme({
+  theme: "light",
+  settings: {
+    background: "#ffffff", // 배경색
+    foreground: "#000000", // 기본 텍스트 색상
+    caret: "#0e7c61", // 커서 색상
+    selection: "#d7d4f0", // 선택 영역 색상
+    selectionMatch: "#d7d4f0", // 선택된 단어 색상
+    gutterBackground: "#f7f7f7", // 라인 번호 배경
+    gutterForeground: "#333333", // 라인 번호 색상
+    gutterBorder: "#dddddd", // 라인 번호 테두리
+    lineHighlight: "#f3f3f3", // 현재 라인 하이라이트 배경
+  },
+  styles: [
+    { tag: t.comment, color: "#3f7f5f", fontStyle: "italic" }, // 주석
+    { tag: t.definition(t.typeName), color: "#d35400" }, // 타입 정의
+    { tag: t.typeName, color: "#d35400" }, // 타입 이름
+    { tag: t.tagName, color: "#7f0055" }, // 태그 이름
+    { tag: t.variableName, color: "#0000ff" }, // 변수 이름
+    { tag: t.string, color: "#2a00ff" }, // 문자열
+    { tag: t.number, color: "#164" }, // 숫자
+    { tag: t.keyword, color: "#7f0055", fontWeight: "bold" }, // 키워드
+    { tag: t.function(t.variableName), color: "#795e26" }, // 함수명
+    { tag: t.operator, color: "#000000" }, // 연산자
+  ],
+});
 
 /**
  * CodeViewer 컴포넌트는 선택된 파일의 코드를 CodeMirror를 사용하여 화면에 표시하는 역할을 합니다.
@@ -91,7 +120,7 @@ export default function CodeViewer() {
               highlightLinePlugin([...highlightLine]),
             ]}
             editable={false}
-            theme={eclipse}
+            theme={eclipseTheme}
             //onChange={(value) => {
             //  console.log("value:", value);
             //}}


### PR DESCRIPTION
## 🚨 관련 이슈

#163

## 🚀 작업 내용

- global.css 원래대로 수정
- createTheme을 사용한 eclipse 테마 적용
  ```js
    const eclipseTheme = createTheme({
      theme: "light",
      settings: {
        background: "#ffffff", // 배경색
        foreground: "#000000", // 기본 텍스트 색상
        caret: "#0e7c61", // 커서 색상
        selection: "#d7d4f0", // 선택 영역 색상
        selectionMatch: "#d7d4f0", // 선택된 단어 색상
        gutterBackground: "#f7f7f7", // 라인 번호 배경
        gutterForeground: "#333333", // 라인 번호 색상
        gutterBorder: "#dddddd", // 라인 번호 테두리
        lineHighlight: "#f3f3f3", // 현재 라인 하이라이트 배경
      },
      styles: [
        { tag: t.comment, color: "#3f7f5f", fontStyle: "italic" }, // 주석
        { tag: t.definition(t.typeName), color: "#d35400" }, // 타입 정의
        { tag: t.typeName, color: "#d35400" }, // 타입 이름
        { tag: t.tagName, color: "#7f0055" }, // 태그 이름
        { tag: t.variableName, color: "#0000ff" }, // 변수 이름
        { tag: t.string, color: "#2a00ff" }, // 문자열
        { tag: t.number, color: "#164" }, // 숫자
        { tag: t.keyword, color: "#7f0055", fontWeight: "bold" }, // 키워드
        { tag: t.function(t.variableName), color: "#795e26" }, // 함수명
        { tag: t.operator, color: "#000000" }, // 연산자
      ],
    });
  ```
  - local에서는 정상적으로 테마 적용되는거 확인함.

